### PR TITLE
Fix test errors from linting issues - fixes #15

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,10 +1,10 @@
 'use strict';
 const path = require('path');
 
-// rules per remark-lint 4.0.2
+// Rules per remark-lint 4.0.2
 
 module.exports = {
-	'reset': true,
+	reset: true,
 	'blockquote-indentation': 2,
 	'checkbox-character-style': {
 		checked: 'x',
@@ -60,8 +60,8 @@ module.exports = {
 	'table-pipes': true,
 	'unordered-list-marker-style': '-',
 
-	// plugins
-	'external': [
+	// Plugins
+	external: [
 		'remark-lint-no-empty-sections',
 		'remark-lint-no-url-trailing-slash',
 		// 'remark-lint-are-links-valid',

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const toVfile = require('to-vfile');
 const vfileReporterPretty = require('vfile-reporter-pretty');
 const config = require('./config');
 
-const m = module.exports = opts => {
+const m = opts => {
 	opts = Object.assign({
 		filename: 'readme.md'
 	}, opts);
@@ -39,3 +39,5 @@ m.report = opts => m(opts).then(file => {
 
 	console.log(vfileReporterPretty([file]));
 });
+
+module.exports = m;

--- a/test/api.js
+++ b/test/api.js
@@ -2,5 +2,5 @@ import test from 'ava';
 import m from '../';
 
 test('main', async t => {
-	t.true((await m({filename: 'fixtures/main.md'})).messages.length > 0);
+	t.true((await m({filename: 'test/fixtures/main.md'})).messages.length > 0);
 });

--- a/test/cli.js
+++ b/test/cli.js
@@ -2,6 +2,6 @@ import test from 'ava';
 import execa from 'execa';
 
 test(async t => {
-	const err = await t.throws(execa.stdout('../cli.js', ['fixtures/main.md']));
+	const err = await t.throws(execa.stdout('./cli.js', ['test/fixtures/main.md']));
 	t.regex(err.message, /Missing Awesome badge/);
 });

--- a/test/rules.js
+++ b/test/rules.js
@@ -2,13 +2,13 @@ import test from 'ava';
 import m from '../';
 
 test('badge - missing', async t => {
-	const result = (await m({filename: 'fixtures/badge.md'})).messages[0];
+	const result = (await m({filename: 'test/fixtures/badge.md'})).messages[0];
 	t.is(result.ruleId, 'awesome/badge');
 	t.is(result.message, 'Missing Awesome badge after the main heading');
 });
 
 test('badge - incorrect source', async t => {
-	const result = (await m({filename: 'fixtures/badge2.md'})).messages[0];
+	const result = (await m({filename: 'test/fixtures/badge2.md'})).messages[0];
 	t.is(result.ruleId, 'awesome/badge');
 	t.is(result.message, 'Incorrect badge source');
 });


### PR DESCRIPTION
This fixes most of the errors from test failures I can reproduce locally (in issue #15), but then I encountered a bunch of issues with the paths to the test fixtures and the `execa.stdout` calls. Something seems up. Any ideas?

Stacktrace
<details>
<pre><code>% npm test                                 /opt/awesome-lint (fix-local-errors)

> awesome-lint@0.1.0 test /opt/awesome-lint
> xo && ava


  4 failed

  api › main
  /opt/awesome-lint/index.js:18

   17:   if (!readmeFile) {                                                     
   18:     return Promise.reject(new Error(`Couldn't find the file ${opts.filen…
   19:   }                                                                      

  Rejected promise returned by test

  Rejection reason:

    [Error: Couldn't find the file fixtures/main.md]

  m (index.js:18:25)
  Test.<anonymous> (test/api.js:5:16)
  step (test/api.js:16:191)
  Test.<anonymous> (test/api.js:16:99)
  Test.__dirname [as fn] (test/api.js:4:1)



  rules › badge - missing
  /opt/awesome-lint/index.js:18

   17:   if (!readmeFile) {                                                     
   18:     return Promise.reject(new Error(`Couldn't find the file ${opts.filen…
   19:   }                                                                      

  Rejected promise returned by test

  Rejection reason:

    [Error: Couldn't find the file fixtures/badge.md]

  m (index.js:18:25)
  Test.<anonymous> (test/rules.js:5:24)
  step (test/rules.js:13:191)
  Test.<anonymous> (test/rules.js:13:99)
  Test.__dirname [as fn] (test/rules.js:4:1)



  rules › badge - incorrect source
  /opt/awesome-lint/index.js:18

   17:   if (!readmeFile) {                                                     
   18:     return Promise.reject(new Error(`Couldn't find the file ${opts.filen…
   19:   }                                                                      

  Rejected promise returned by test

  Rejection reason:

    [Error: Couldn't find the file fixtures/badge2.md]

  m (index.js:18:25)
  Test.<anonymous> (test/rules.js:11:24)
  step (test/rules.js:13:191)
  Test.<anonymous> (test/rules.js:13:99)
  Test.__dirname [as fn] (test/rules.js:10:1)



  cli › [anonymous]
  /opt/awesome-lint/test/cli.js:6

   5:   const err = await t.throws(execa.stdout('../cli.js', ['fixtures/main.md…
   6:   t.regex(err.message, /Missing Awesome badge/);                          
   7: });                                                                       

  Value must match expression:

    "spawn ../cli.js ENOENT"

  Regular expression:

    /Missing Awesome badge/

  err.message
  => "spawn ../cli.js ENOENT"

  err
  => [Error: spawn ../cli.js ENOENT]

  Test.<anonymous> (test/cli.js:6:4)
  step (test/cli.js:16:191)

npm ERR! Test failed.  See above for more details.</code></pre>
</details>
