### PR TITLE
Add rule awesome/toc

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
 		"cli"
 	],
 	"dependencies": {
+		"github-slugger": "^1.2.0",
 		"globby": "^8.0.1",
+		"mdast-util-to-string": "^1.0.4",
 		"meow": "^5.0.0",
 		"pify": "^3.0.0",
 		"remark": "^9.0.0",
@@ -85,6 +87,11 @@
 		"remark-lint-unordered-list-marker-style": "^1.0.2",
 		"to-vfile": "^5.0.0",
 		"unified-lint-rule": "^1.0.3",
+		"unist-util-find": "^1.0.1",
+		"unist-util-find-all-after": "^1.0.2",
+		"unist-util-find-all-before": "^2.0.2",
+		"unist-util-find-all-between": "^1.0.1",
+		"unist-util-inspect": "^4.1.3",
 		"unist-util-visit": "^1.1.0",
 		"vfile-reporter-pretty": "^1.0.2"
 	},

--- a/rules/index.js
+++ b/rules/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
 module.exports = [
-	require('./badge')
+	require('./badge'),
+	require('./toc')
 ];

--- a/rules/toc.js
+++ b/rules/toc.js
@@ -128,19 +128,19 @@ function validateListItems({ast, file, list, headingLinks, headings, depth}) {
 				return;
 			}
 
-			if (depth < maxListItemDepth) {
-				const nextHeading = headings[index + 1];
-				const subHeadings = nextHeading ? findAllBetween(ast, heading, nextHeading, {
-					type: 'heading',
-					depth: depth + 3
-				}) : findAllAfter(ast, heading, {
-					type: 'heading',
-					depth: depth + 3
-				});
+			const subList = find(listItem, n => n.type === 'list');
 
-				const subList = find(listItem, n => n.type === 'list');
+			if (subList) {
+				if (depth < maxListItemDepth) {
+					const nextHeading = headings[index + 1];
+					const subHeadings = nextHeading ? findAllBetween(ast, heading, nextHeading, {
+						type: 'heading',
+						depth: depth + 3
+					}) : findAllAfter(ast, heading, {
+						type: 'heading',
+						depth: depth + 3
+					});
 
-				if (subList) {
 					validateListItems({
 						ast,
 						file,
@@ -149,6 +149,8 @@ function validateListItems({ast, file, list, headingLinks, headings, depth}) {
 						headings: subHeadings,
 						depth: depth + 1
 					});
+				} else {
+					file.message(`Exceeded max depth of ${maxListItemDepth + 1} levels`);
 				}
 			}
 		}

--- a/rules/toc.js
+++ b/rules/toc.js
@@ -1,0 +1,163 @@
+'use strict';
+const find = require('unist-util-find');
+const findAllAfter = require('unist-util-find-all-after');
+const findAllBefore = require('unist-util-find-all-before');
+const findAllBetween = require('unist-util-find-all-between');
+const rule = require('unified-lint-rule');
+const GitHubSlugger = require('github-slugger');
+const toString = require('mdast-util-to-string');
+const visit = require('unist-util-visit');
+
+const slugger = new GitHubSlugger();
+
+const maxListItemDepth = 1;
+
+module.exports = rule('remark-lint:awesome/toc', (ast, file) => {
+	slugger.reset();
+
+	const headingLinks = buildHeadingLinks(ast);
+
+	const toc = find(ast, node => (
+		node.type === 'heading' &&
+		node.depth === 2 &&
+		toString(node).trim() === 'Contents'
+	));
+
+	if (!toc) {
+		file.message('Missing or invalid Table of Contents', ast);
+		return;
+	}
+
+	const headingsPre = findAllBefore(ast, toc, {
+		type: 'heading'
+	});
+
+	if (headingsPre.length > 1) {
+		file.message('Table of Contents must be the first section', toc);
+	} else if (headingsPre.length === 0) {
+		file.message('First heading should be name of awesome list', toc);
+	}
+
+	const headingsPost = findAllAfter(ast, toc, {
+		type: 'heading',
+		depth: 2
+	}).filter(node => toString(node) !== 'License');
+
+	if (headingsPost.length === 0) {
+		file.message('Missing content headers', ast);
+		return;
+	}
+
+	const tocLists = findAllBetween(ast, toc, headingsPost[0], 'list');
+
+	if (tocLists.length === 0) {
+		file.message('Missing or invalid Table of Contents list', toc);
+	} else if (tocLists.length > 1) {
+		file.message('Multiple Table of Contents lists found', toc);
+	} else {
+		const tocList = tocLists[0];
+
+		// Validate list items recursively
+		validateListItems({
+			ast,
+			file,
+			list: tocList,
+			headingLinks,
+			headings: headingsPost,
+			depth: 0
+		});
+	}
+});
+
+function buildHeadingLinks(ast) {
+	const links = {};
+
+	visit(ast, 'heading', node => {
+		const text = toString(node);
+		const slug = slugger.slug(text);
+		const link = `#${slug}`;
+
+		links[link] = node;
+	});
+
+	return links;
+}
+
+function validateListItems({ast, file, list, headingLinks, headings, depth}) {
+	let index = 0;
+
+	if (list) {
+		for (; index < list.children.length; ++index) {
+			const listItem = list.children[index];
+			const link = find(listItem, n => n.type === 'link');
+
+			if (!link) {
+				file.message(`ToC item "${index}" missing link "${toString(listItem)}"`, listItem);
+				return;
+			}
+
+			const {url} = link;
+			const text = toString(link);
+			const heading = headings[index];
+			const headingText = heading && toString(heading);
+
+			if (!text) {
+				file.message(`ToC item "${url}" missing link text`, listItem);
+				return;
+			}
+
+			if (!headingText) {
+				file.message(`ToC item "${text}" missing corresponding heading`, listItem);
+				return;
+			}
+
+			if (text !== headingText) {
+				file.message(`ToC item "${text}" does not match corresponding heading "${headingText}"`, listItem);
+				return;
+			}
+
+			const headingLink = headingLinks[url];
+
+			if (headingLink) {
+				headingLinks[url] = false;
+			} else if (headingLink === undefined) {
+				file.message(`ToC item "${text}" link "${url}" not found`, listItem);
+				return;
+			} else {
+				file.message(`ToC item "${text}" has duplicate link "${url}"`, listItem);
+				return;
+			}
+
+			if (depth < maxListItemDepth) {
+				const nextHeading = headings[index + 1];
+				const subHeadings = nextHeading ? findAllBetween(ast, heading, nextHeading, {
+					type: 'heading',
+					depth: depth + 3
+				}) : findAllAfter(ast, heading, {
+					type: 'heading',
+					depth: depth + 3
+				});
+
+				const subList = find(listItem, n => n.type === 'list');
+
+				if (subList) {
+					validateListItems({
+						ast,
+						file,
+						list: subList,
+						headingLinks,
+						headings: subHeadings,
+						depth: depth + 1
+					});
+				}
+			}
+		}
+	}
+
+	if (index < headings.length) {
+		for (let i = index; i < headings.length; ++i) {
+			const heading = headings[i];
+			file.message(`ToC missing item for "${toString(heading)}"`, list);
+		}
+	}
+}

--- a/rules/toc.js
+++ b/rules/toc.js
@@ -15,6 +15,7 @@ const maxListItemDepth = 1;
 module.exports = rule('remark-lint:awesome/toc', (ast, file) => {
 	slugger.reset();
 
+	// Heading links are order-dependent, so it's important to gather them up front.
 	const headingLinks = buildHeadingLinks(ast);
 
 	const toc = find(ast, node => (
@@ -57,7 +58,7 @@ module.exports = rule('remark-lint:awesome/toc', (ast, file) => {
 	} else {
 		const tocList = tocLists[0];
 
-		// Validate list items recursively
+		// Validate list items against heading sections recursively
 		validateListItems({
 			ast,
 			file,
@@ -152,6 +153,9 @@ function validateListItems({ast, file, list, headingLinks, headings, depth}) {
 				} else {
 					file.message(`Exceeded max depth of ${maxListItemDepth + 1} levels`);
 				}
+			} else {
+				// No need to enforce the existence of a subList, even if there are corresponding
+				// subHeadings.
 			}
 		}
 	}

--- a/rules/toc.js
+++ b/rules/toc.js
@@ -161,8 +161,8 @@ function validateListItems({ast, file, list, headingLinks, headings, depth}) {
 	}
 
 	if (index < headings.length) {
-		for (let i = index; i < headings.length; ++i) {
-			const heading = headings[i];
+		for (; index < headings.length; ++index) {
+			const heading = headings[index];
 			file.message(`ToC missing item for "${toString(heading)}"`, list);
 		}
 	}

--- a/rules/toc.js
+++ b/rules/toc.js
@@ -120,11 +120,14 @@ function validateListItems({ast, file, list, headingLinks, headings, depth}) {
 			const headingLink = headingLinks[url];
 
 			if (headingLink) {
+				// Remember that we've referenced this link previously
 				headingLinks[url] = false;
 			} else if (headingLink === undefined) {
+				// This link doesn't exist as a section in the content
 				file.message(`ToC item "${text}" link "${url}" not found`, listItem);
 				return;
 			} else {
+				// This link was used previously, so it must be a duplicate
 				file.message(`ToC item "${text}" has duplicate link "${url}"`, listItem);
 				return;
 			}

--- a/rules/toc.js
+++ b/rules/toc.js
@@ -15,7 +15,7 @@ const maxListItemDepth = 1;
 module.exports = rule('remark-lint:awesome/toc', (ast, file) => {
 	slugger.reset();
 
-	// Heading links are order-dependent, so it's important to gather them up front.
+	// Heading links are order-dependent, so it's important to gather them up front
 	const headingLinks = buildHeadingLinks(ast);
 
 	const toc = find(ast, node => (

--- a/test/fixtures/toc0.md
+++ b/test/fixtures/toc0.md
@@ -1,0 +1,35 @@
+# Title [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+
+## Contents
+
+- [Foo](#foo)
+- [Bar](#bar)
+- [Baz](#baz)
+
+## Foo
+
+### Foo A
+
+non-empty
+
+### Foo B
+
+non-empty
+
+## Bar
+
+### Bar A
+
+non-empty
+
+### Bar
+
+non-empty
+
+## Baz
+
+non-empty
+
+## License
+
+non-empty

--- a/test/fixtures/toc1.md
+++ b/test/fixtures/toc1.md
@@ -1,0 +1,39 @@
+# Title [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+
+## Contents
+
+- [Foo](#foo)
+  - [Foo A](#foo-a)
+  - [Foo B](#foo-b)
+- [Bar](#bar)
+  - [Bar A](#bar-a)
+  - [Bar](#bar-1)
+- [Baz](#baz)
+
+## Foo
+
+### Foo A
+
+non-empty
+
+### Foo B
+
+non-empty
+
+## Bar
+
+### Bar A
+
+non-empty
+
+### Bar
+
+non-empty
+
+## Baz
+
+non-empty
+
+## License
+
+non-empty

--- a/test/fixtures/toc2.md
+++ b/test/fixtures/toc2.md
@@ -1,0 +1,39 @@
+# Title [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+
+## Table of Contents
+
+- [Foo](#foo)
+  - [Foo A](#foo-a)
+  - [Foo B](#foo-b)
+- [Bar](#bar)
+  - [Bar A](#bar-a)
+  - [Bar](#bar-1)
+- [Baz](#baz)
+
+## Foo
+
+### Foo A
+
+non-empty
+
+### Foo B
+
+non-empty
+
+## Bar
+
+### Bar A
+
+non-empty
+
+### Bar
+
+non-empty
+
+## Baz
+
+non-empty
+
+## License
+
+non-empty

--- a/test/fixtures/toc3.md
+++ b/test/fixtures/toc3.md
@@ -1,0 +1,36 @@
+# Title [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+
+## Contents
+
+- [Foo](#foo)
+  - [Foo A](#foo-a)
+- [Bar](#bar)
+  - [Bar](#bar-1)
+
+## Foo
+
+### Foo A
+
+non-empty
+
+### Foo B
+
+non-empty
+
+## Bar
+
+### Bar A
+
+non-empty
+
+### Bar
+
+non-empty
+
+## Baz
+
+non-empty
+
+## License
+
+non-empty

--- a/test/fixtures/toc4.md
+++ b/test/fixtures/toc4.md
@@ -1,0 +1,49 @@
+# Title [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+
+## Contents
+
+- [Foo](#foo)
+  - [Foo A](#foo-a)
+    - [Test 0](#test-0)
+    - [Test 1](#test-1)
+  - [Foo B](#foo-b)
+- [Bar](#bar)
+  - [Bar A](#bar-a)
+  - [Bar](#bar-1)
+- [Baz](#baz)
+
+## Foo
+
+### Foo A
+
+non-empty
+
+### Test 0
+
+non-empty
+
+### Test 1
+
+non-empty
+
+### Foo B
+
+non-empty
+
+## Bar
+
+### Bar A
+
+non-empty
+
+### Bar
+
+non-empty
+
+## Baz
+
+non-empty
+
+## License
+
+non-empty

--- a/test/rules/badge.js
+++ b/test/rules/badge.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import m from '..';
+import m from '../..';
 
 test('badge - missing', async t => {
 	const result = (await m({filename: 'test/fixtures/badge.md'})).messages[0];

--- a/test/rules/toc.js
+++ b/test/rules/toc.js
@@ -1,0 +1,29 @@
+import test from 'ava';
+import m from '../..';
+
+test('toc - success basic', async t => {
+	const result = (await m({filename: 'test/fixtures/toc0.md'})).messages;
+	t.deepEqual(result, []);
+});
+
+test('toc - success sub-lists', async t => {
+	const result = (await m({filename: 'test/fixtures/toc1.md'})).messages;
+	t.deepEqual(result, []);
+});
+
+test('toc - missing', async t => {
+	const result = (await m({filename: 'test/fixtures/toc2.md'})).messages[0];
+	t.is(result.ruleId, 'awesome/toc');
+	t.is(result.message, 'Missing or invalid Table of Contents');
+});
+
+test('toc - missing items', async t => {
+	const {messages} = await m({filename: 'test/fixtures/toc3.md'});
+	t.is(messages.length, 3);
+	t.is(messages[0].ruleId, 'awesome/toc');
+	t.is(messages[0].message, 'ToC missing item for "Foo B"');
+	t.is(messages[1].ruleId, 'awesome/toc');
+	t.is(messages[1].message, 'ToC item "Bar" does not match corresponding heading "Bar A"');
+	t.is(messages[2].ruleId, 'awesome/toc');
+	t.is(messages[2].message, 'ToC missing item for "Baz"');
+});

--- a/test/rules/toc.js
+++ b/test/rules/toc.js
@@ -27,3 +27,9 @@ test('toc - missing items', async t => {
 	t.is(messages[2].ruleId, 'awesome/toc');
 	t.is(messages[2].message, 'ToC missing item for "Baz"');
 });
+
+test('toc - exceed max depth', async t => {
+	const result = (await m({filename: 'test/fixtures/toc4.md'})).messages[0];
+	t.is(result.ruleId, 'awesome/toc');
+	t.is(result.message, 'Exceeded max depth of 2 levels');
+});


### PR DESCRIPTION
First pass at addressing #4.

- [x] Ensure the first section is named Contents.
- [x] Ensure all the links point to existing sections with the same name.
- [x] Ensure all sections are included except for the License section.
- [x] Ensure the Contents list is maximum 2 levels.
- [x] Ensure the sections follow the order of the table.
- [x] Ensure sub-sections align up to 2 levels deep (this limit is easily configurable).
  - Note that if a sub-list is present in the ToC, then we make sure its contents match the sub-sections in the body, but if a sub-list is **not** present, then we ignore any possible sub-sections in the body.

This PR won't handle all possible TOC issues, but it should handle the majority of them.

@sindresorhus @wooorm note that instead of breaking this implementation out into a dozen or so individual rules as suggested in #4, I chose to KISS for now. In the short term, it'll be a lot easier for development and maintenance to have them all implemented in one place than spread across multiple files or packages. If we find this functionality generally useful, we can always break it out into more general, encapsulated rules in the future.