### PR TITLE
Add rule awesome/license

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const config = require('./config');
 
 const m = options => {
 	options = Object.assign({
+		config,
 		filename: 'readme.md'
 	}, options);
 
@@ -17,7 +18,7 @@ const m = options => {
 		return Promise.reject(new Error(`Couldn't find the file ${options.filename}`));
 	}
 
-	const run = remark().use(config).process;
+	const run = remark().use(options.config).process;
 	const file = toVfile.readSync(readmeFile);
 
 	return pify(run)(file);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 	],
 	"dependencies": {
 		"globby": "^8.0.1",
+		"mdast-util-to-string": "^1.0.4",
 		"meow": "^5.0.0",
 		"pify": "^3.0.0",
 		"remark": "^9.0.0",
@@ -85,6 +86,8 @@
 		"remark-lint-unordered-list-marker-style": "^1.0.2",
 		"to-vfile": "^5.0.0",
 		"unified-lint-rule": "^1.0.3",
+		"unist-util-find": "^1.0.1",
+		"unist-util-find-all-after": "^1.0.2",
 		"unist-util-visit": "^1.1.0",
 		"vfile-reporter-pretty": "^1.0.2"
 	},

--- a/rules/index.js
+++ b/rules/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
 module.exports = [
-	require('./badge')
+	require('./badge'),
+	require('./license')
 ];

--- a/rules/license.js
+++ b/rules/license.js
@@ -1,0 +1,35 @@
+'use strict';
+const find = require('unist-util-find');
+const findAllAfter = require('unist-util-find-all-after');
+const rule = require('unified-lint-rule');
+const toString = require('mdast-util-to-string');
+
+module.exports = rule('remark-lint:awesome/license', (ast, file) => {
+	const license = find(ast, node => (
+		node.type === 'heading' &&
+		node.depth === 2 &&
+		toString(node) === 'License'
+	));
+
+	if (!license) {
+		file.message('Missing License section', ast);
+		return;
+	}
+
+	const headingsPost = findAllAfter(ast, license, {
+		type: 'heading',
+		depth: 2
+	});
+
+	if (headingsPost.length > 0) {
+		file.message('License must be the last section', headingsPost[0]);
+		return;
+	}
+
+	const children = findAllAfter(ast, license, () => true);
+	const content = toString({type: 'root', children});
+
+	if (!content) {
+		file.message('License must not be empty', license);
+	}
+});

--- a/test/fixtures/license-error-0.md
+++ b/test/fixtures/license-error-0.md
@@ -1,0 +1,13 @@
+# Title
+
+## Contents
+
+- [Foo](#foo)
+
+## Foo
+
+non-empty
+
+## LICENSE
+
+This is an invalid license section.

--- a/test/fixtures/license-error-1.md
+++ b/test/fixtures/license-error-1.md
@@ -1,0 +1,11 @@
+# Title
+
+## Contents
+
+- [Foo](#foo)
+
+## Foo
+
+non-empty
+
+## License

--- a/test/fixtures/license-error-2.md
+++ b/test/fixtures/license-error-2.md
@@ -1,0 +1,13 @@
+# Title
+
+## Contents
+
+- [Foo](#foo)
+
+## License
+
+This license is invalid because it is not the last section.
+
+## Foo
+
+non-empty

--- a/test/fixtures/license-success-0.md
+++ b/test/fixtures/license-success-0.md
@@ -1,0 +1,15 @@
+# Title
+
+## Contents
+
+- [Foo](#foo)
+
+## Foo
+
+non-empty
+
+## License
+
+[![CC0](http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
+
+To the extent possible under law, [Sindre Sorhus](http://sindresorhus.com) has waived all copyright and related or neighboring rights to this work.

--- a/test/license.js
+++ b/test/license.js
@@ -1,0 +1,35 @@
+import test from 'ava';
+import m from '..';
+
+const config = {
+	plugins: [
+		require('remark-lint'),
+		// TODO: remark-lint-no-empty-sections doesn't handle empty last section
+		// https://github.com/vhf/remark-lint-no-empty-sections/issues/3
+		require('remark-lint-no-empty-sections'),
+		require('../rules/license')
+	]
+};
+
+test('license - missing', async t => {
+	const result = (await m({config, filename: 'test/fixtures/license-error-0.md'})).messages[0];
+	t.is(result.ruleId, 'awesome/license');
+	t.is(result.message, 'Missing License section');
+});
+
+test('license - empty', async t => {
+	const result = (await m({config, filename: 'test/fixtures/license-error-1.md'})).messages[0];
+	t.is(result.ruleId, 'awesome/license');
+	t.is(result.message, 'License must not be empty');
+});
+
+test('license - not last section', async t => {
+	const result = (await m({config, filename: 'test/fixtures/license-error-2.md'})).messages[0];
+	t.is(result.ruleId, 'awesome/license');
+	t.is(result.message, 'License must be the last section');
+});
+
+test('license - success', async t => {
+	const {messages} = (await m({config, filename: 'test/fixtures/license-success-0.md'}));
+	t.falsy(messages.find(message => message.ruleId === 'awesome/license'));
+});


### PR DESCRIPTION
Fixes #6.

- [x] Ensure that a section named `License` exists with depth 2.
- [x] Ensure that `License` is the last section in the document.
- [x] Ensure that `License` is not empty.

This PR doesn't do any additional license validation against CC0 or any other licenses. If desired, we can add that in a future pass.