### PR TITLE
Add `lib` directory to `files` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"index.js",
 		"config.js",
 		"cli.js",
+		"lib",
 		"rules"
 	],
 	"keywords": [


### PR DESCRIPTION
This was just missing previously.

We should probably also bump awesome-lint version after this.