### PR TITLE
Add more words to rule awesome/spell-check

### DIFF
--- a/lib/spell-check-rules.js
+++ b/lib/spell-check-rules.js
@@ -12,5 +12,21 @@ module.exports = [
 	{
 		test: /\bjavascript\b/gi,
 		value: 'JavaScript'
+	},
+	{
+		test: /\bmac\s?OS\b/gi,
+		value: 'macOS'
+	},
+	{
+		test: /\bYou\s?Tube\b/gi,
+		value: 'YouTube'
+	},
+	{
+		test: /\bFFmpeg\b/gi,
+		value: 'FFmpeg'
+	},
+	{
+		test: /\bGit\s?Hub\b/gi,
+		value: 'GitHub'
 	}
 ];


### PR DESCRIPTION
I added all of the words/terms in #36 (and so this closes #36 unless you think the issue should be kept open for suggestions in the future).
I'd also like to add "open source" (inspired by [this comment](https://github.com/atomiclabs/hyperdex/pull/472#issuecomment-412956036)) to the rule, but I'm not sure how this term should be handled, as one could write "Open source"  if used in the beginning of a sentence. Also, the term could be written as "open-source".