### PR TITLE
Refactor CLI and main to allow programmatic usage

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,11 +1,6 @@
 #!/usr/bin/env node
 'use strict';
-const gitClone = require('git-clone');
-const isUrl = require('is-url-superb');
 const meow = require('meow');
-const pify = require('pify');
-const rmfr = require('rmfr');
-const tempy = require('tempy');
 
 const findReadmeFile = require('./lib/find-readme-file');
 const awesomeLint = require('.');
@@ -18,32 +13,14 @@ const main = async () => {
 
 	const options = { };
 	const input = cli.input[0];
-	let temp = null;
 
 	if (input) {
-		if (isUrl(input)) {
-			temp = tempy.directory();
-			await pify(gitClone)(input, temp);
-
-			const readme = findReadmeFile(temp);
-			if (!readme) {
-				await rmfr(temp);
-				throw new Error(`Unable to find valid readme for "${input}"`);
-			}
-
-			options.filename = readme;
-		} else {
-			options.filename = input;
-		}
+		options.filename = input;
 	} else {
-		options.filename = 'readme.md';
+		options.filename = findReadmeFile(process.cwd());
 	}
 
 	await awesomeLint.report(options);
-
-	if (temp) {
-		await rmfr(temp);
-	}
 };
 
 main();

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"bin": "cli.js",
+	"main": "index.js",
 	"engines": {
 		"node": ">=8"
 	},


### PR DESCRIPTION
This is a small change that moves the current CLI functionality of cloning a repo into the main `lint.report` export.

It also adds support for using the module as a library instead of only as a CLI.

This should also fix #33.