### PR TITLE
Allow British spelling of 'Licence'

### DIFF
--- a/rules/license.js
+++ b/rules/license.js
@@ -8,7 +8,7 @@ const visit = require('unist-util-visit');
 module.exports = rule('remark-lint:awesome/license', (ast, file) => {
 	const license = find(ast, node => (
 		node.type === 'heading' &&
-		toString(node) === 'License'
+		(toString(node) === 'Licence' || toString(node) === 'License')
 	));
 
 	if (!license) {

--- a/rules/toc.js
+++ b/rules/toc.js
@@ -15,6 +15,7 @@ const maxListItemDepth = 1;
 const sectionHeadingBlacklist = new Set([
 	'Contribute',
 	'Contributing',
+	'Licence',
 	'License'
 ]);
 


### PR DESCRIPTION
Add accepting British spelling of '[Licence](https://dictionary.cambridge.org/dictionary/english/licence)' (spelt with -ce) as a correct spelling in the License and TOC rules