### PR TITLE
Consider upper as valid list item prefix case

### DIFF
--- a/rules/list-item.js
+++ b/rules/list-item.js
@@ -14,7 +14,8 @@ const listItemPrefixCaseWhitelist = new Set([
 	'camel',
 	'capital',
 	'constant',
-	'pascal'
+	'pascal',
+	'upper'
 ]);
 
 // Valid node types in list item link

--- a/test/fixtures/list-item/0.md
+++ b/test/fixtures/list-item/0.md
@@ -34,6 +34,8 @@ These are valid list items that don't need a description.
 - [ironNode](https://github.com/s-a/iron-node) - Node.js debugger supporting ES2015 out of the box.
 - [i2c-bus](https://github.com/fivdi/i2c-bus) - I2C serial bus access.
 - [Mark Text](https://github.com/marktext/marktext) - Real-time preview Markdown editor.
+- [iqvoc](https://github.com/innoq/iqvoc) - SKOS(-XL) Vocabulary Management System for the Semantic Web.
+- [Bridge](https://github.com/bridgedotnet/Bridge) - C# to JavaScript transpiler. Write modern mobile and web apps in C# and run them anywhere in JavaScript.
 
 - [foo](https://foo.com) - "Catan" inspired board game.
 - [foo](https://foo.com) - 'About This App' window.


### PR DESCRIPTION
Fixes #52.

Upper case should be also considered as valid. And I added those 2 cases into tests.
