### PR TITLE
Add rule awesome/heading

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
 		"remark-lint-unordered-list-marker-style": "^1.0.2",
 		"rmfr": "^2.0.0",
 		"tempy": "^0.2.1",
+		"to-title-case": "^1.0.0",
 		"to-vfile": "^5.0.0",
 		"unified-lint-rule": "^1.0.3",
 		"unist-util-find": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
 		"remark-lint-unordered-list-marker-style": "^1.0.2",
 		"rmfr": "^2.0.0",
 		"tempy": "^0.2.1",
-		"to-title-case": "^1.0.0",
 		"to-vfile": "^5.0.0",
 		"unified-lint-rule": "^1.0.3",
 		"unist-util-find": "^1.0.1",

--- a/rules/heading.js
+++ b/rules/heading.js
@@ -7,19 +7,15 @@ module.exports = rule('remark-lint:awesome/heading', (ast, file) => {
 	let headings = 0;
 
 	visit(ast, node => {
-		if (node.type !== 'heading') {
+		if (node.type !== 'heading' || node.depth !== 1) {
 			return;
-		}
-
-		if (node.depth !== 1) {
-			file.message(`The list heading's children array must flat`, node);
 		}
 
 		for (const child of node.children) {
 			if (child.type !== 'text') {
 				continue;
 			}
-			
+
 			const headingText = child.value;
 
 			if (headingText !== titleCase(headingText)) {

--- a/rules/heading.js
+++ b/rules/heading.js
@@ -1,7 +1,12 @@
 'use strict';
 const rule = require('unified-lint-rule');
 const visit = require('unist-util-visit');
-const titleCase = require('to-title-case');
+const {of: caseOf, title: titleCase} = require('case');
+
+const listHeadingCaseWhitelist = new Set([
+	'title',
+	'capital'
+]);
 
 module.exports = rule('remark-lint:awesome/heading', (ast, file) => {
 	let headings = 0;
@@ -26,7 +31,7 @@ module.exports = rule('remark-lint:awesome/heading', (ast, file) => {
 
 			const headingText = child.value;
 
-			if (headingText !== titleCase(headingText)) {
+			if (!listHeadingCaseWhitelist.has(caseOf(headingText)) && titleCase(headingText) !== headingText) {
 				file.message('Main heading must be in title case', node);
 			}
 		}

--- a/rules/heading.js
+++ b/rules/heading.js
@@ -1,0 +1,40 @@
+'use strict';
+const rule = require('unified-lint-rule');
+const visit = require('unist-util-visit');
+const titleCase = require('to-title-case');
+
+module.exports = rule('remark-lint:awesome/heading', (ast, file) => {
+	let headings = 0;
+
+	visit(ast, node => {
+		if (node.type !== 'heading') {
+			return;
+		}
+
+		if (node.depth !== 1) {
+			file.message(`The list heading's children array must flat`, node);
+		}
+
+		for (const child of node.children) {
+			if (child.type !== 'text') {
+				continue;
+			}
+			
+			const headingText = child.value;
+
+			if (headingText !== titleCase(headingText)) {
+				file.message('List heading must be in title case', node);
+			}
+		}
+
+		headings++;
+
+		if (headings > 1) {
+			file.message('List can only have one heading', node);
+		}
+	});
+
+	if (headings === 0) {
+		file.message('Missing main list heading');
+	}
+});

--- a/rules/heading.js
+++ b/rules/heading.js
@@ -6,9 +6,17 @@ const titleCase = require('to-title-case');
 module.exports = rule('remark-lint:awesome/heading', (ast, file) => {
 	let headings = 0;
 
-	visit(ast, node => {
-		if (node.type !== 'heading' || node.depth !== 1) {
+	visit(ast, (node, index) => {
+		if (node.type !== 'heading') {
 			return;
+		}
+
+		if (node.depth > 1) {
+			if (index !== 0) {
+				return;
+			}
+
+			file.message('Main list heading must be of depth 1', node);
 		}
 
 		for (const child of node.children) {
@@ -19,7 +27,7 @@ module.exports = rule('remark-lint:awesome/heading', (ast, file) => {
 			const headingText = child.value;
 
 			if (headingText !== titleCase(headingText)) {
-				file.message('List heading must be in title case', node);
+				file.message('Main heading must be in title case', node);
 			}
 		}
 

--- a/rules/index.js
+++ b/rules/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = [
+	require('./heading'),
 	require('./badge'),
 	require('./contributing'),
 	require('./git-repo-age'),

--- a/test/fixtures/heading/error0.md
+++ b/test/fixtures/heading/error0.md
@@ -1,0 +1,1 @@
+> This is an awesome list!

--- a/test/fixtures/heading/error1.md
+++ b/test/fixtures/heading/error1.md
@@ -1,0 +1,3 @@
+# my-awesome-list
+
+> This is an awesome list!

--- a/test/fixtures/heading/error2.md
+++ b/test/fixtures/heading/error2.md
@@ -1,0 +1,3 @@
+# Awesome List
+
+# This Is a Really Awesome List

--- a/test/fixtures/heading/error3.md
+++ b/test/fixtures/heading/error3.md
@@ -1,0 +1,1 @@
+## Improper Awesome List

--- a/test/fixtures/heading/success0.md
+++ b/test/fixtures/heading/success0.md
@@ -1,0 +1,3 @@
+# My Awesome List
+
+> This is an awesome list

--- a/test/fixtures/heading/success1.md
+++ b/test/fixtures/heading/success1.md
@@ -1,0 +1,1 @@
+# AHA Acronyms Are Allowed

--- a/test/rules/heading.js
+++ b/test/rules/heading.js
@@ -23,7 +23,7 @@ test('heading - not in title case', async t => {
 	t.deepEqual(messages, [
 		{
 			ruleId: 'awesome/heading',
-			message: 'List heading must be in title case'
+			message: 'Main heading must be in title case'
 		}
 	]);
 });
@@ -34,6 +34,16 @@ test('heading - more than one heading', async t => {
 		{
 			ruleId: 'awesome/heading',
 			message: 'List can only have one heading'
+		}
+	]);
+});
+
+test('heading - depth is bigger than 1', async t => {
+	const messages = await lint({config, filename: 'test/fixtures/heading/error3.md'})
+	t.deepEqual(messages, [
+		{
+			ruleId: 'awesome/heading',
+			message: 'Main list heading must be of depth 1'
 		}
 	]);
 });

--- a/test/rules/heading.js
+++ b/test/rules/heading.js
@@ -39,7 +39,7 @@ test('heading - more than one heading', async t => {
 });
 
 test('heading - depth is bigger than 1', async t => {
-	const messages = await lint({config, filename: 'test/fixtures/heading/error3.md'})
+	const messages = await lint({config, filename: 'test/fixtures/heading/error3.md'});
 	t.deepEqual(messages, [
 		{
 			ruleId: 'awesome/heading',

--- a/test/rules/heading.js
+++ b/test/rules/heading.js
@@ -52,3 +52,8 @@ test('heading - success', async t => {
 	const messages = await lint({config, filename: 'test/fixtures/heading/success0.md'});
 	t.deepEqual(messages, []);
 });
+
+test('heading - success (with acronyms)', async t => {
+	const messages = await lint({config, filename: 'test/fixtures/heading/success1.md'});
+	t.deepEqual(messages, []);
+});

--- a/test/rules/heading.js
+++ b/test/rules/heading.js
@@ -1,0 +1,44 @@
+import test from 'ava';
+import lint from '../_lint';
+
+const config = {
+	plugins: [
+		require('remark-lint'),
+		require('../../rules/heading')
+	]
+};
+
+test('heading - missing', async t => {
+	const messages = await lint({config, filename: 'test/fixtures/heading/error0.md'});
+	t.deepEqual(messages, [
+		{
+			ruleId: 'awesome/heading',
+			message: 'Missing main list heading'
+		}
+	]);
+});
+
+test('heading - not in title case', async t => {
+	const messages = await lint({config, filename: 'test/fixtures/heading/error1.md'});
+	t.deepEqual(messages, [
+		{
+			ruleId: 'awesome/heading',
+			message: 'List heading must be in title case'
+		}
+	]);
+});
+
+test('heading - more than one heading', async t => {
+	const messages = await lint({config, filename: 'test/fixtures/heading/error2.md'});
+	t.deepEqual(messages, [
+		{
+			ruleId: 'awesome/heading',
+			message: 'List can only have one heading'
+		}
+	]);
+});
+
+test('heading - success', async t => {
+	const messages = await lint({config, filename: 'test/fixtures/heading/success0.md'});
+	t.deepEqual(messages, []);
+});


### PR DESCRIPTION
The `awesome/heading` rule lints all of the given file's headings, verifying that:

- There is exactly one heading.
- It's in title case.
- It's children array is flat (i.e. it doesn't have any nested and complicated child elements).

Fixes #59