### PR TITLE
Improve awesome/git-repo-age error message

### DIFF
--- a/rules/git-repo-age.js
+++ b/rules/git-repo-age.js
@@ -35,9 +35,8 @@ module.exports = rule('remark-lint:awesome/git-repo-age', async (ast, file) => {
 			file.message(`Git repository must be at least ${minGitRepoAgeDays} days old`);
 		}
 	} catch (_) {
-		// Not a Git repository or a shallow copy missing the
-		// .travis.yml "git:\ndepth: false" setting
-		file.message('Awesome list must reside in a valid deep-cloned git repository (see https://github.com/sindresorhus/awesome-lint#tip for more information)');
+		// Not a Git repository or a shallow copy missing the `.travis.yml` `git:\ndepth: false` setting
+		file.message('Awesome list must reside in a valid deep-cloned Git repository (see https://github.com/sindresorhus/awesome-lint#tip for more information)');
 	}
 });
 

--- a/rules/git-repo-age.js
+++ b/rules/git-repo-age.js
@@ -35,8 +35,9 @@ module.exports = rule('remark-lint:awesome/git-repo-age', async (ast, file) => {
 			file.message(`Git repository must be at least ${minGitRepoAgeDays} days old`);
 		}
 	} catch (_) {
-		// Most likely not a Git repository
-		file.message('Awesome list must reside in a valid git repository');
+		// Not a Git repository or a shallow copy missing the
+		// .travis.yml "git:\ndepth: false" setting
+		file.message('Awesome list must reside in a valid deep-cloned git repository (see https://github.com/sindresorhus/awesome-lint#tip for more information)');
 	}
 });
 

--- a/test/rules/git-repo-age.js
+++ b/test/rules/git-repo-age.js
@@ -30,7 +30,7 @@ test.serial('git-repo-age - error invalid git repo', async t => {
 	t.deepEqual(messages, [
 		{
 			ruleId: 'awesome/git-repo-age',
-			message: 'Awesome list must reside in a valid git repository'
+			message: 'Awesome list must reside in a valid deep-cloned git repository (see https://github.com/sindresorhus/awesome-lint#tip for more information)'
 		}
 	]);
 });

--- a/test/rules/git-repo-age.js
+++ b/test/rules/git-repo-age.js
@@ -30,7 +30,7 @@ test.serial('git-repo-age - error invalid git repo', async t => {
 	t.deepEqual(messages, [
 		{
 			ruleId: 'awesome/git-repo-age',
-			message: 'Awesome list must reside in a valid deep-cloned git repository (see https://github.com/sindresorhus/awesome-lint#tip for more information)'
+			message: 'Awesome list must reside in a valid deep-cloned Git repository (see https://github.com/sindresorhus/awesome-lint#tip for more information)'
 		}
 	]);
 });


### PR DESCRIPTION
The "Awesome list must reside in a valid git repository" error message
(awesome/git-repo-age) also appears when (e.g. Travis) makes a shallow
copy of the awesome repo.  This is documented in the README file, but
users may miss it.  Rephrase error message and add a pointer to the
README file.