### PR TITLE
Allow `.github` directory to contain contribution guidelines

### DIFF
--- a/rules/contributing.js
+++ b/rules/contributing.js
@@ -7,7 +7,7 @@ const rule = require('unified-lint-rule');
 module.exports = rule('remark-lint:awesome-contributing', (ast, file) => {
 	const {dirname} = file;
 
-        const contributingFile = globby.sync(['{.github/,}{contributing}.md'], {nocase: true, cwd: dirname})[0];
+	const contributingFile = globby.sync(['{.github/,}{contributing}.md'], {nocase: true, cwd: dirname})[0];
 	// TODO: This doesn't work on Linux for some reason. Investigate and then open an issue on `fast-glob`.
 	// const contributingFile = globby.sync('contributing.md', {case: false, cwd: dirname})[0];
 

--- a/rules/contributing.js
+++ b/rules/contributing.js
@@ -7,7 +7,7 @@ const rule = require('unified-lint-rule');
 module.exports = rule('remark-lint:awesome-contributing', (ast, file) => {
 	const {dirname} = file;
 
-	const contributingFile = globby.sync(['{.github/,}{contributing}.md'], {nocase: true, cwd: dirname})[0];
+	const contributingFile = globby.sync(['{.github/,}contributing.md'], {nocase: true, cwd: dirname})[0];
 	// TODO: This doesn't work on Linux for some reason. Investigate and then open an issue on `fast-glob`.
 	// const contributingFile = globby.sync('contributing.md', {case: false, cwd: dirname})[0];
 

--- a/rules/contributing.js
+++ b/rules/contributing.js
@@ -7,7 +7,7 @@ const rule = require('unified-lint-rule');
 module.exports = rule('remark-lint:awesome-contributing', (ast, file) => {
 	const {dirname} = file;
 
-	const contributingFile = globby.sync(['contributing.md', 'CONTRIBUTING.md'], {cwd: dirname})[0];
+        const contributingFile = globby.sync(['{.github/,}{contributing}.md'], {nocase: true, cwd: dirname})[0];
 	// TODO: This doesn't work on Linux for some reason. Investigate and then open an issue on `fast-glob`.
 	// const contributingFile = globby.sync('contributing.md', {case: false, cwd: dirname})[0];
 


### PR DESCRIPTION
[Like `code-of-conduct.md` file](https://github.com/sindresorhus/awesome-lint/commit/ddbebd140ae6a11d193c55d84889cbf93f9bb747#diff-168726dbe96b3ce427e7fedce31bb0bcR38), `contribution.md` is allowed to be placed in the `.github` subfolder of a repository.


> To help your project contributors do good work, you can add a file with contribution guidelines to your project repository's root, `docs`, or `.github` folder. 

Source: https://help.github.com/en/github/building-a-strong-community/setting-guidelines-for-repository-contributors 