### PR TITLE
Add test fixtures for line breaks support.

### DIFF
--- a/test/fixtures/list-item/0.md
+++ b/test/fixtures/list-item/0.md
@@ -28,6 +28,21 @@ These are valid list items that don't need a description.
 - [How to Write a Video Player in Less Than 1k Lines](https://dranger.com/ffmpeg)
 - [Learn FFmpeg libav the Hard Way](https://github.com/leandromoreira/ffmpeg-libav-tutorial)
 
+## Line Breaks
+
+Very long descriptions should be allowed to be broken, as per Markdown
+specification:
+
+- [Link 1](https://foo.com) - Description of line 1.
+- [Link 2](https://foo.com) - A very long description for the second link in
+  the list. That description is more than 80 characters wide.
+- [This is a very long title, pointing to an awesome article on incredible
+  stuff we're not used to see everyday](https://foo.com) - Line \#3's
+  description.
+- [Link number
+  three](https://this-is-a-very-long-url-that-is-pointing-to-a-really-really-great-website.com) -
+  Fourth description.
+
 ## Edge Cases
 
 - [dat](https://dat-data.com) - Real-time replication and versioning for data sets.


### PR DESCRIPTION
This is a proposal to allow for line breaks in both link titles and descriptions.

I updated the fixtures to demonstrate the feature I look forward to implement. Of course tests are failing. But if the community validates that format, I can update that PR to implement the corresponding rules.