### PR TITLE
Allow for a Footnotes section at the end of an Awesome list

### DIFF
--- a/rules/toc.js
+++ b/rules/toc.js
@@ -16,7 +16,8 @@ const sectionHeadingBlacklist = new Set([
 	'Contribute',
 	'Contributing',
 	'Licence',
-	'License'
+	'License',
+    'Footnotes'
 ]);
 
 module.exports = rule('remark-lint:awesome-toc', (ast, file) => {

--- a/rules/toc.js
+++ b/rules/toc.js
@@ -17,7 +17,7 @@ const sectionHeadingBlacklist = new Set([
 	'Contributing',
 	'Licence',
 	'License',
-    'Footnotes'
+	'Footnotes'
 ]);
 
 module.exports = rule('remark-lint:awesome-toc', (ast, file) => {

--- a/test/fixtures/toc/0.md
+++ b/test/fixtures/toc/0.md
@@ -30,6 +30,14 @@ non-empty
 
 non-empty
 
+## Contributing
+
+non-empty
+
 ## License
+
+non-empty
+
+## Footnotes
 
 non-empty

--- a/test/fixtures/toc/1.md
+++ b/test/fixtures/toc/1.md
@@ -34,6 +34,14 @@ non-empty
 
 non-empty
 
-## License
+## Contribute
+
+non-empty
+
+## Licence
+
+non-empty
+
+## Footnotes
 
 non-empty

--- a/test/fixtures/toc/2.md
+++ b/test/fixtures/toc/2.md
@@ -37,3 +37,11 @@ non-empty
 ## License
 
 non-empty
+
+## Contribute
+
+non-empty
+
+## Footnotes
+
+non-empty

--- a/test/fixtures/toc/3.md
+++ b/test/fixtures/toc/3.md
@@ -31,6 +31,14 @@ non-empty
 
 non-empty
 
-## License
+## Footnotes
+
+non-empty
+
+## Licence
+
+non-empty
+
+## Contribute
 
 non-empty

--- a/test/fixtures/toc/4.md
+++ b/test/fixtures/toc/4.md
@@ -44,6 +44,14 @@ non-empty
 
 non-empty
 
-## License
+## Footnotes
+
+non-empty
+
+## Contribute
+
+non-empty
+
+## Licence
 
 non-empty

--- a/test/fixtures/toc/5.md
+++ b/test/fixtures/toc/5.md
@@ -17,3 +17,7 @@ This section should be ignored.
 ## License
 
 This section should be ignored.
+
+## Footnotes
+
+This section should be ignored.


### PR DESCRIPTION
That way we can group non-important but necessary content (like extra-copyright notices, hyperlinks to sources, pointers to expansive content, ...) at the end of the document while keeping the main content hyper-focused to our curated awesome lists.

Fixes #117 .

Real-life example available on the `Awesome Falsehood` project at: https://github.com/kdeldycke/awesome-falsehood/blob/d8db15ad0c6b0acaea1e6da1f48ea4a5922d4118/readme.md#footnotes