### PR TITLE
Permit &mdash; as a list item link separator

### DIFF
--- a/rules/list-item.js
+++ b/rules/list-item.js
@@ -166,8 +166,8 @@ function validateListItemDescription(description, file) {
 			return false;
 		}
 
-		if (/^\s*—/.test(prefixText)) {
-			file.message('List item link and description separated by invalid en-dash', prefix);
+		if (/^\s*(—)|(&mdash;) /.test(prefixText)) {
+			file.message('List item link and description separated by invalid em-dash', prefix);
 			return false;
 		}
 

--- a/test/fixtures/list-item/1.md
+++ b/test/fixtures/list-item/1.md
@@ -10,7 +10,7 @@ All list-items in this document should be linted as **invalid**.
     - [foo](https://foo.com) - invalid sub-item description.
 
 - [foo](https://foo.com) - Breaking space nbsp instead of a normal " " character.
-- [foo](https://foo.com) — Unicode en-dash instead of normal "-" character.
+- [foo](https://foo.com) — Unicode em-dash instead of normal "-" character.
 
 - [sparkly](https://github.com/sindresorhus/sparkly) - Generate sparklines ▁▂▃▅▂▇
 - [cat-ascii-faces](https://github.com/melaniecebula/cat-ascii-faces) - ₍˄·͈༝·͈˄₎◞ ̑̑ෆ⃛ (=ↀωↀ=)✧ (^･o･^)ﾉ”


### PR DESCRIPTION
Sometimes it's more convenient to write `&nbsp;` rather than —.