### PR TITLE
Forbid License, Licence and Contribute sections

### DIFF
--- a/rules/index.js
+++ b/rules/index.js
@@ -6,7 +6,7 @@ module.exports = [
 	require('./contributing'),
 	require('./git-repo-age'),
 	require('./github'),
-	/// require('./license'),
+	require('./license'),
 	require('./list-item'),
 	require('./no-ci-badge'),
 	require('./spell-check'),

--- a/rules/license.js
+++ b/rules/license.js
@@ -1,9 +1,7 @@
 'use strict';
 const find = require('unist-util-find');
-const findAllAfter = require('unist-util-find-all-after');
 const rule = require('unified-lint-rule');
 const toString = require('mdast-util-to-string');
-const visit = require('unist-util-visit');
 
 module.exports = rule('remark-lint:awesome-license', (ast, file) => {
 	const license = find(ast, node => (
@@ -11,37 +9,7 @@ module.exports = rule('remark-lint:awesome-license', (ast, file) => {
 		(toString(node) === 'Licence' || toString(node) === 'License')
 	));
 
-	if (!license) {
-		file.message('Missing License section', ast);
-		return;
+	if (license) {
+		file.message('Forbidden license section found', ast);
 	}
-
-	if (license.depth !== 2) {
-		file.message('License section must be at heading depth 2', license);
-		return;
-	}
-
-	const headingsPost = findAllAfter(ast, license, {
-		type: 'heading'
-	});
-
-	if (headingsPost.length > 0) {
-		file.message('License must be the last section', headingsPost[0]);
-		return;
-	}
-
-	const children = findAllAfter(ast, license, () => true);
-	const content = {type: 'root', children};
-	const value = toString(content);
-
-	if (!value) {
-		file.message('License must not be empty', license);
-	}
-
-	visit(content, 'image', node => {
-		if (/\.png/i.test(node.url)) {
-			file.message('License image must be SVG', node);
-			return false;
-		}
-	});
 });

--- a/rules/toc.js
+++ b/rules/toc.js
@@ -13,10 +13,7 @@ const slugger = new GitHubSlugger();
 const maxListItemDepth = 1;
 
 const sectionHeadingBlacklist = new Set([
-	'Contribute',
 	'Contributing',
-	'Licence',
-	'License',
 	'Footnotes'
 ]);
 

--- a/test/fixtures/license/error0.md
+++ b/test/fixtures/license/error0.md
@@ -8,6 +8,6 @@
 
 non-empty
 
-## LICENSE
+## Licence
 
-This is an invalid license section.
+Licence section is forbidden.

--- a/test/fixtures/license/error2.md
+++ b/test/fixtures/license/error2.md
@@ -6,7 +6,7 @@
 
 ## License
 
-This license is invalid because it is not the last section.
+License section is forbidden, even if first section.
 
 ## Foo
 

--- a/test/fixtures/license/error3.md
+++ b/test/fixtures/license/error3.md
@@ -10,4 +10,4 @@ non-empty
 
 # License
 
-This license is invalid because its heading should be at depth 2.
+License is forbidden even at depth 1.

--- a/test/fixtures/license/error4.md
+++ b/test/fixtures/license/error4.md
@@ -2,4 +2,4 @@
 
 [![CC4](https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by.png)](https://creativecommons.org/licenses/by/4.0/)
 
-This license is invalid because it points to a png instead of an svg.
+License is forbidden even if ut has images.

--- a/test/fixtures/license/success0.md
+++ b/test/fixtures/license/success0.md
@@ -6,10 +6,4 @@
 
 ## Foo
 
-This license section below is 100% valid.
-
-## License
-
-[![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
-
-To the extent possible under law, [Sindre Sorhus](https://sindresorhus.com) has waived all copyright and related or neighboring rights to this work.
+This list is 100% valid because it has no license section.

--- a/test/fixtures/toc/0.md
+++ b/test/fixtures/toc/0.md
@@ -34,10 +34,6 @@ non-empty
 
 non-empty
 
-## License
-
-non-empty
-
 ## Footnotes
 
 non-empty

--- a/test/fixtures/toc/1.md
+++ b/test/fixtures/toc/1.md
@@ -34,11 +34,7 @@ non-empty
 
 non-empty
 
-## Contribute
-
-non-empty
-
-## Licence
+## Contributing
 
 non-empty
 

--- a/test/fixtures/toc/2.md
+++ b/test/fixtures/toc/2.md
@@ -34,11 +34,7 @@ non-empty
 
 non-empty
 
-## License
-
-non-empty
-
-## Contribute
+## Contributing
 
 non-empty
 

--- a/test/fixtures/toc/3.md
+++ b/test/fixtures/toc/3.md
@@ -35,10 +35,6 @@ non-empty
 
 non-empty
 
-## Licence
-
-non-empty
-
-## Contribute
+## Contributing
 
 non-empty

--- a/test/fixtures/toc/4.md
+++ b/test/fixtures/toc/4.md
@@ -48,10 +48,6 @@ non-empty
 
 non-empty
 
-## Contribute
-
-non-empty
-
-## Licence
+## Contributing
 
 non-empty

--- a/test/fixtures/toc/5.md
+++ b/test/fixtures/toc/5.md
@@ -6,15 +6,7 @@
 
 ## Foo
 
-## Contribute
-
-This section should be ignored.
-
 ## Contributing
-
-This section should be ignored.
-
-## License
 
 This section should be ignored.
 

--- a/test/rules/license.js
+++ b/test/rules/license.js
@@ -4,66 +4,61 @@ import lint from '../_lint';
 const config = {
 	plugins: [
 		require('remark-lint'),
-		/// require('remark-lint-no-empty-sections'),
 		require('../../rules/license')
 	]
 };
 
-test('license - missing', async t => {
+test('licence - forbidden section', async t => {
 	const messages = await lint({config, filename: 'test/fixtures/license/error0.md'});
 	t.deepEqual(messages, [
 		{
 			line: 1,
 			ruleId: 'awesome-license',
-			message: 'Missing License section'
+			message: 'Forbidden license section found'
 		}
 	]);
 });
 
-test('license - empty', async t => {
+test('license - forbidden empty section', async t => {
 	const messages = await lint({config, filename: 'test/fixtures/license/error1.md'});
 	t.deepEqual(messages, [
-		// {
-		// 	ruleId: 'no-empty-sections',
-		// 	message: 'Remove empty section: "License"'
-		// },
 		{
-			line: 11,
+			line: 1,
 			ruleId: 'awesome-license',
-			message: 'License must not be empty'
+			message: 'Forbidden license section found'
 		}
 	]);
 });
 
-test('license - not last section', async t => {
+test('license - forbidden last section', async t => {
 	const messages = await lint({config, filename: 'test/fixtures/license/error2.md'});
 	t.deepEqual(messages, [
 		{
-			line: 11,
+			line: 1,
 			ruleId: 'awesome-license',
-			message: 'License must be the last section'
+			message: 'Forbidden license section found'
 		}
 	]);
 });
 
-test('license - incorrect heading depth', async t => {
+test('license - forbidden heading depth section', async t => {
 	const messages = await lint({config, filename: 'test/fixtures/license/error3.md'});
 	t.deepEqual(messages, [
 		{
-			line: 11,
+			line: 1,
 			ruleId: 'awesome-license',
-			message: 'License section must be at heading depth 2'
+			message: 'Forbidden license section found'
 		}
 	]);
 });
 
-test('license - png image', async t => {
+test('license - forbidden image section', async t => {
 	const messages = await lint({config, filename: 'test/fixtures/license/error4.md'});
 	t.deepEqual(messages, [
 		{
-			line: 3,
+			line: 1,
 			ruleId: 'awesome-license',
-			message: 'License image must be SVG'
+			message: 'Forbidden license section found'
 		}
 	]);
 });


### PR DESCRIPTION
This PR backports and enforces new rules discussed with @sindresorhus in https://github.com/sindresorhus/awesome/pull/1860 :

1. Force the optional contribution section to be named `Contributing`. `Contribute` is no longer allowed, as per https://github.com/sindresorhus/awesome/pull/1860#discussion_r496219219
2. Forbid `Licence` or `License` section. The preferred method is to rely on GitHub's license detection. See https://github.com/sindresorhus/awesome/pull/1860#discussion_r496217532

This PR related to:
* https://github.com/sindresorhus/awesome-lint/issues/93
* https://github.com/sindresorhus/awesome-lint/issues/91