### PR TITLE
Allow using emphasis text style in link title

### DIFF
--- a/rules/list-item.js
+++ b/rules/list-item.js
@@ -20,6 +20,7 @@ const listItemPrefixCaseWhitelist = new Set([
 
 // Valid node types in list item link
 const listItemLinkNodeWhitelist = new Set([
+	'emphasis',
 	'inlineCode',
 	'text'
 ]);

--- a/test/fixtures/list-item/0.md
+++ b/test/fixtures/list-item/0.md
@@ -44,6 +44,7 @@ These are valid list items that don't need a description.
 - [Mark Text](https://github.com/marktext/marktext) - Real-time preview Markdown editor.
 - [iqvoc](https://github.com/innoq/iqvoc) - SKOS(-XL) Vocabulary Management System for the Semantic Web.
 - [Bridge](https://github.com/bridgedotnet/Bridge) - C# to JavaScript transpiler. Write modern mobile and web apps in C# and run them anywhere in JavaScript.
+- [Elisabeth Engel (@_lizzelo_)](https://twitter.com/_lizzelo_)
 
 - [foo](https://foo.com) - "Catan" inspired board game.
 - [foo](https://foo.com) - 'About This App' window.


### PR DESCRIPTION
Fixes #95.