### PR TITLE
Skip URLs in spell check rule

### DIFF
--- a/rules/spell-check.js
+++ b/rules/spell-check.js
@@ -1,4 +1,5 @@
 'use strict';
+const isUrl = require('is-url-superb');
 const rule = require('unified-lint-rule');
 const visit = require('unist-util-visit');
 const arrify = require('arrify');
@@ -14,20 +15,29 @@ module.exports = rule('remark-lint:awesome-spell-check', (ast, file) => {
 			return;
 		}
 
+		const sanitizedSegments = [];
+		for (const segment of node.value.split(/\s/g)) {
+			if (!isUrl(segment)) {
+				sanitizedSegments.push(segment);
+			}
+		}
+
+		const sanitizedValue = sanitizedSegments.join(' ');
+
 		for (const rule of spellCheckRules) {
 			const {test, value} = rule;
 			const regs = arrify(test).map(reg => new RegExp(reg));
 
 			for (const re of regs) {
 				for (;;) {
-					const match = re.exec(node.value);
+					const match = re.exec(sanitizedValue);
 					if (!match) {
 						break;
 					}
 
 					if (match[0] !== value) {
-						const previousCharacter = node.value[match.index - 1];
-						const nextCharacter = node.value[match.index + match[0].length];
+						const previousCharacter = sanitizedValue[match.index - 1];
+						const nextCharacter = sanitizedValue[match.index + match[0].length];
 
 						if (wordBreakCharacterWhitelist.has(previousCharacter)) {
 							continue;

--- a/test/fixtures/spell-check/success0.md
+++ b/test/fixtures/spell-check/success0.md
@@ -30,3 +30,6 @@ These are special-cases which should not cause errors.
 You might also like [awesome-nodejs](https://github.com/sindresorhus/awesome-nodejs).
 - [awesome-github](https://github.com/phillipadsmith/awesome-github) -
 [GitHub]( https://github.com) is awesome.
+- [https://github.com/phillipadsmith/awesome-github](https://github.com/phillipadsmith/awesome-github) -
+[GitHub]( https://github.com) is awesome.
+- https://github.com/sindresorhus/awesome is meta awesome.


### PR DESCRIPTION
Remove URL segments from input values to skip them during validation. 

Closes #71
Closes #132