### PR TITLE
Add apostrophe to word tokenization list allowing possessive forms

### DIFF
--- a/rules/list-item.js
+++ b/rules/list-item.js
@@ -238,7 +238,7 @@ function validateListItemSpecialCases(description, descriptionText) {
 }
 
 function tokenizeWords(text) {
-	return text.split(/[- ;./]/).filter(Boolean);
+	return text.split(/[- ;./']/).filter(Boolean);
 }
 
 function validateListItemPrefixCasing(prefix, file) {

--- a/test/fixtures/list-item/0.md
+++ b/test/fixtures/list-item/0.md
@@ -24,6 +24,7 @@ All list-items in this document should be linted as **valid**.
   - [foo](https://foo.com) - Valid sub-item.
   - [foo](https://foo.com) - Valid sub-item.
     - [foo](https://foo.com) - Valid sub-sub-item!!!!!
+- [foo](https://foo.com) - GitHub's descriptions can also be valid.	
 
 ## Tutorials
 


### PR DESCRIPTION
Fixes #148 

I would like to propose adding the apostrophe symbol for word tokenization, so that the linter does not complain on possessive forms.

The integration tests don't run locally for me (due to missing API access, happy to help fix that if someone can guide me). The local tests after my addition appear unchanged (no additional failures):
```
  6 warnings


  9 tests failed
  2 known failures

  rules › code-of-conduct › code-of-conduct - invalid if has placeholder
  rules › code-of-conduct › code-of-conduct - invalid if just copied
```

In order to clearly separate the added test from the tokenization change, I have _not_ squashed local commits. Apologies if this PR does violate the Contribution Guidelines for that. I'm happy to help in the future and happy to learn from this issue to submit better PRs in the future.