### PR TITLE
Allow apostrophe and interpunct in first word of item description

### DIFF
--- a/rules/list-item.js
+++ b/rules/list-item.js
@@ -250,7 +250,7 @@ function validateListItemPrefixCasing(prefix, file) {
 		return false;
 	}
 
-	if (!listItemPrefixCaseAllowList.has(caseOf(firstWord.replace(/[^\w]+/g, ''))) && !/\d/.test(firstWord) && !/^["“'(]/.test(firstWord) && !identifierAllowList.has(firstWord)) {
+	if (!listItemPrefixCaseAllowList.has(caseOf(firstWord.replace(/\W+/g, ''))) && !/\d/.test(firstWord) && !/^["“'(]/.test(firstWord) && !identifierAllowList.has(firstWord)) {
 		file.message('List item description must start with valid casing', prefix);
 		return false;
 	}

--- a/rules/list-item.js
+++ b/rules/list-item.js
@@ -250,7 +250,7 @@ function validateListItemPrefixCasing(prefix, file) {
 		return false;
 	}
 
-	if (!listItemPrefixCaseAllowList.has(caseOf(firstWord.replace(/['·]/,''))) && !/\d/.test(firstWord) && !/^["“'(]/.test(firstWord) && !identifierAllowList.has(firstWord)) {
+	if (!listItemPrefixCaseAllowList.has(caseOf(firstWord.replace(/[^\w]+/g, ''))) && !/\d/.test(firstWord) && !/^["“'(]/.test(firstWord) && !identifierAllowList.has(firstWord)) {
 		file.message('List item description must start with valid casing', prefix);
 		return false;
 	}

--- a/rules/list-item.js
+++ b/rules/list-item.js
@@ -250,7 +250,7 @@ function validateListItemPrefixCasing(prefix, file) {
 		return false;
 	}
 
-	if (!listItemPrefixCaseAllowList.has(caseOf(firstWord)) && !/\d/.test(firstWord) && !/^["“'(]/.test(firstWord) && !identifierAllowList.has(firstWord)) {
+	if (!listItemPrefixCaseAllowList.has(caseOf(firstWord.replace(/['·]/,''))) && !/\d/.test(firstWord) && !/^["“'(]/.test(firstWord) && !identifierAllowList.has(firstWord)) {
 		file.message('List item description must start with valid casing', prefix);
 		return false;
 	}


### PR DESCRIPTION
Fixes #153.

This PR fixes the errors that appear when having apostrophes or interpuncts in the first word of the description. Examples that produced an error but now pass:

````
- [GPT-3](https://openai.com/api/) - OpenAI's API provides access to GPT-3, which performs a wide variety of natural language tasks, and Codex, which translates natural language to code.
- [DALL·E 2](https://openai.com/dall-e-2/) - DALL·E 2 by OpenAI is a new AI system that can create realistic images and art from a description in natural language.
````