### PR TITLE
add pre-commit config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: awesome-lint
+    name: Awesome Lint
+    description: Linter for Awesome lists
+    entry: awesome-lint
+    language: node
+    pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,4 @@
     entry: awesome-lint
     language: node
     pass_filenames: false
+    always_run: true


### PR DESCRIPTION
This PR is intended to implement https://github.com/sindresorhus/awesome-lint/issues/154 based on the docs at https://pre-commit.com/#new-hooks

It's not quite working but I think perhaps I am just missing something simple.

How I'm testing:

1. I've cloned https://github.com/sindresorhus/awesome locally. 
2. I run `pre-commit try-repo local\path\to\awesome-lint`
3. pre-commit installs `awesome-lint` and runs it and fails with `Invalid GitHub repo URL: local\path\to\awesome\readme.md`

However, I can repro this same issue when just directly running `awesome-lint` locally on `awesome`:
```
PS local\path\to\awesome> npx awesome-lint
Need to install the following packages:
  awesome-lint@0.18.1
Ok to proceed? (y) y
✖ Invalid GitHub repo URL: local\path\to\awesome\readme.md
```
I think I'm hitting this bit of code: https://github.com/sindresorhus/awesome-lint/blob/main/index.js#L65-L68 - and it thinks my local path is a url? Might just be an issue with Windows or PowerShell. 🤔 