### PR TITLE
Do not assume remote name is `origin` in `remark-lint:awesome-github`

### DIFF
--- a/rules/github.js
+++ b/rules/github.js
@@ -8,11 +8,22 @@ module.exports = rule('remark-lint:awesome-github', async (ast, file) => {
 	const {dirname} = file;
 
 	try {
+		const gitBranch = await execa.stdout('git', [
+			'branch',
+			'--show-current'
+		]);
+
+		const remoteName = await execa.stdout('git', [
+			'config',
+			'--get',
+			`branch.${gitBranch}.remote`
+		]);
+
 		const remoteUrl = await execa.stdout('git', [
 			'remote',
 			'get-url',
 			'--push',
-			'origin'
+			remoteName
 		], {
 			cwd: dirname
 		});


### PR DESCRIPTION
The rule `remark-lint:awesome-github` has false negatives when the remote name is `origin`. More detail in the linked issue.

Closes #169