### PR TITLE
chore: Fix missing file extension lint error

### DIFF
--- a/test/integration.js
+++ b/test/integration.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import lint from '..';
+import lint from '../index.js';
 import findReadmeFile from '../lib/find-readme-file.js';
 
 /**


### PR DESCRIPTION
CI breaks all builds due to this linting issue.

Once this is merged, #170 can be re-ran