### PR TITLE
fix: If remote cannot be inferred, default to config `clone.defaultRemoteName`, then `origin`

### DIFF
--- a/rules/github.js
+++ b/rules/github.js
@@ -13,11 +13,26 @@ module.exports = rule('remark-lint:awesome-github', async (ast, file) => {
 			'--show-current'
 		]);
 
-		const remoteName = await execa.stdout('git', [
-			'config',
-			'--get',
-			`branch.${gitBranch}.remote`
-		]);
+		let remoteName;
+		if (gitBranch) {
+			remoteName = await execa.stdout('git', [
+				'config',
+				'--get',
+				`branch.${gitBranch}.remote`
+			]);
+		} else {
+			// If HEAD does not point to a branch, it is in a detached state.
+			// This can occur with '@actions/checkout'. In such cases, we read
+			// it from the config key 'clone.defaultRemoteName'. If that is not
+			// set, then it is defaulted to 'origin'. See #172 for details.
+			remoteName = await execa.stdout('git', [
+				'config',
+				'--default',
+				'origin',
+				'--get',
+				'clone.defaultRemoteName'
+			]);
+		}
 
 		const remoteUrl = await execa.stdout('git', [
 			'remote',


### PR DESCRIPTION
From [this comment](https://github.com/sindresorhus/awesome-lint/issues/172#issuecomment-1732057902) in the referrenced issue:

> This broke linting because the code did not take into account that HEAD may not point to a branch - it could be in a detached state. And this commonly occurs in Github Actions when @actions/checkout is used to clone a repository.

If we are not currently in a branch, then we:

- Infer remote name from the config key `clone.defaultRemoteName`
- If that config key is not set, then the value is defaulted to 'origin' (the original default)

These fixes were tested in [this PR](https://github.com/fox-forks/awesome-google-cloud/pull/1) (and [this PR](https://github.com/fox-forks/awesome-google-cloud/pull/2)), which had CI config like:

```yaml
jobs:
  awesome-lint:
    steps:
      - name: "checkout repo"
        uses: actions/checkout@v2.0.0
        with:
          fetch-depth: 0
      - run: |
          npm install --global 'https://github.com/fox-forks/awesome-lint.git#hyperupcall-detached-state-patch'
          awesome-lint
```

Fixes #172