### PR TITLE
fix: Properly detect 'Contents' header if it includes an HTML comment

### DIFF
--- a/rules/list-item.js
+++ b/rules/list-item.js
@@ -54,7 +54,7 @@ module.exports = rule('remark-lint:awesome-list-item', (ast, file) => {
 	const toc = find(ast, node => (
 		node.type === 'heading' &&
 		node.depth === 2 &&
-		toString(node) === 'Contents'
+		toString(node).replace(/<!--.*?-->/g, '').trim() === 'Contents'
 	));
 
 	if (toc) {

--- a/rules/toc.js
+++ b/rules/toc.js
@@ -26,7 +26,7 @@ module.exports = rule('remark-lint:awesome-toc', (ast, file) => {
 	const toc = find(ast, node => (
 		node.type === 'heading' &&
 		node.depth === 2 &&
-		toString(node).trim() === 'Contents'
+		toString(node).replace(/<!--.*?-->/g, '').trim() === 'Contents'
 	));
 
 	if (!toc) {


### PR DESCRIPTION
Given an Awesome Markdown file that includes the following:

```md
...
## Contents  <!-- omit from toc -->

- [Official](#official)
- [Instances](#instances)
- [Statistics](#statistics)
- [People](#people)
- [Tools](#tools)
...
```

Linting fails because of the `<!-- omit from toc -->` comment.

```sh
$ pnpx awesome-lint
✖ Linting

  README.md:11:3
  ✖   1:1  Missing or invalid Table of Contents  remark-lint:awesome-toc
  ✖  11:3  Invalid list item link URL            remark-lint:awesome-list-item
  ✖  12:3  Invalid list item link URL            remark-lint:awesome-list-item
  ✖  13:3  Invalid list item link URL            remark-lint:awesome-list-item
  ✖  14:3  Invalid list item link URL            remark-lint:awesome-list-item
  ✖  15:3  Invalid list item link URL            remark-lint:awesome-list-item
  ✖  16:3  Invalid list item link URL            remark-lint:awesome-list-item
  ✖  17:3  Invalid list item link URL            remark-lint:awesome-list-item
  ✖  18:3  Invalid list item link URL            remark-lint:awesome-list-item
  ✖  19:3  Invalid list item link URL            remark-lint:awesome-list-item
  ✖  20:3  Invalid list item link URL            remark-lint:awesome-list-item
  ✖  21:3  Invalid list item link URL            remark-lint:awesome-list-item
  ✖  22:3  Invalid list item link URL            remark-lint:awesome-list-item
  ✖  23:3  Invalid list item link URL            remark-lint:awesome-list-item

  14 errors
```

(This comment is useful because it tells the [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one) VSCode extension to exclude it from the auto-generated table of contents, as per Awesome Rules.)

After applying this patch, no more errors are printed.

**After:**

```sh
$ pnpx awesome-lint
✔ Linting
```

Note that the `toString()` function _does_ accept an option called `includeHtml`, but unfortunately that did not help in this case. So this regex seemed like the next best alternative.