### PR TITLE
--offline avoids github tests (no internet); clone depth 1

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -24,12 +24,16 @@ const cli = meow(`
 
 	Options
 	  --reporter, -r  Use a custom reporter
+	  --offline
 `, {
 	importMeta: import.meta,
 	flags: {
 		reporter: {
 			type: 'string',
 			shortFlag: 'r',
+		},
+		offline: {
+			type: 'boolean',
 		},
 	},
 });
@@ -39,6 +43,7 @@ const input = cli.input[0];
 const options = {};
 
 options.filename = input ?? findReadmeFile(process.cwd());
+options.offline = cli.flags.offline ?? false;
 
 const reporterName = cli.flags.reporter;
 if (reporterName) {

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ lint._report = async (options, spinner) => {
 
 	if (isUrl(options.filename)) {
 		if (options.offline) {
-			throw new Error('Attempting to lint url while offline!');
+			throw new Error('Cannot lint URL while offline.');
 		}
 
 		if (!isGithubUrl(options.filename, {repository: true})) {


### PR DESCRIPTION
I was traveling and noticed awesome-lint was very slow without access to github.com. 

I'm sure that's an unusual use case, so maybe it's not worth a dedicated CLI. But in case otherwise, here's the change that I think would avoid needing internet access. 