### PR TITLE
FIX: avoid temp files like .readme.md.swp

### DIFF
--- a/lib/find-readme-file.js
+++ b/lib/find-readme-file.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 export default function findReadmeFile(directory) {
 	const readmeFile = fs.readdirSync(directory).find(filename => (
-		/readme|readme\.md|readme\.markdown|readme.txt/i.test(filename)
+		/^(readme|readme\.md|readme\.markdown|readme.txt)$/i.test(filename)
 	));
 
 	if (readmeFile) {


### PR DESCRIPTION
The default `readme` regexp is very liberal. So much so, it captures vim swap files for me. Is it reasonable to require the filename not have extra characters before or after the matching pattern?

I can imagine forcing `^` could be to strict if filename includes additional path information. but I think `$` should always be reasonable. (and would avoid any vim `.swp`.


And maybe it's entirely unnecessary. I can specify `readme.md` as a CLI argument if i'm worried about swap files. 