### PR TITLE
`awesome-list-item` Fix for "Bug with selection of link to validate" - Fixes #199

### DIFF
--- a/test/fixtures/list-item/0.md
+++ b/test/fixtures/list-item/0.md
@@ -54,6 +54,7 @@ These are valid list items that don't need a description.
 - [foo](https://foo.com) - The so-called `awesome-lint` project.
 
 Test description's ending punctuation.
+
 - [foo](https://foo.com) - Ending with a period.
 - [foo](https://foo.com) - Ending with an exclamation mark!
 - [foo](https://foo.com) - Ending with a question mark?
@@ -80,7 +81,7 @@ Test description's ending punctuation.
 - [foo](https://foo.com) - “Article's quote full of edge cases with non-balanced quote marks . But too long to be in full (…) so here is the best part — making an important point — with a twist.”
 
 - [foo](https://foo.com) - Ending with a parenthetical. (Japanese)
-- [foo](https://foo.com) - Ending with an emphasis parenthetical. *(Japanese)*
+- [foo](https://foo.com) - Ending with an emphasis parenthetical. _(Japanese)_
 - [foo](https://foo.com) - Ending with a strong parenthetical. **(Japanese)**
 
 - [foo](https://foo.com) - Ending with an emoji case 1. 📷
@@ -89,63 +90,70 @@ Test description's ending punctuation.
 - [foo](https://foo.com) - Ending with an emoji case 3. ⌚
 
 These list items are special-cases which replace punctuation with emoji.
+
 - [foo](https://foo.com) 💲
 - [foo](https://foo.com) - [Preview](https://read.amazon.com/kp/embed?asin=B01G7TTKSK&asin=B01G7TTKSK&preview=newtab&linkCode=kpe&ref_=cm_sw_r_kb_dp_DLhOxb0XZ3MEC) 💲
 
 These list items are special-cases which have simple descripitions and no dash separator.
+
 - [foo](https://foo.com) (parenthetical)
-- [foo](https://foo.com) *(emphasis parenthetical)*
+- [foo](https://foo.com) _(emphasis parenthetical)_
 - [foo](https://foo.com) **(strong parenthetical)**
 - [foo](https://foo.com) (parenthetical with emoji) 📷
-- [foo](https://foo.com) *(emphasis parenthetica with emojil)* 📷
+- [foo](https://foo.com) _(emphasis parenthetica with emojil)_ 📷
 - [foo](https://foo.com) **(strong parenthetica with emojil)** 📷
 
 These list items use inline code in the link text.
+
 - [`@electronjs` on Twitter](https://twitter.com/electronjs)
 - [`#node.js` on Freenode](https://webchat.freenode.net/?channels=node.js)
-- [`@electron_ru` on Telegram](https://telegram.me/electron_ru) *(Russian)*
+- [`@electron_ru` on Telegram](https://telegram.me/electron_ru) _(Russian)_
 
 These list items start with common lower-case acronyms.
+
 - [foo](https://foo.com) - npm is awesome.
 - [foo](https://foo.com) - iOS is awesome.
 - [foo](https://foo.com) - macOS is awesome.
 
 - [macOS](https://github.com/iCHAIT/awesome-macOS#readme)
+
   - [Command-Line](https://github.com/herrbischoff/awesome-macos-command-line#readme)
 
 - Promises
-	- [bar](https://bar.com)
-	- [bar](https://bar.com)
+  - [bar](https://bar.com)
+  - [bar](https://bar.com)
 - Observables
-	- [bar](https://bar.com)
+  - [bar](https://bar.com)
 
 These sub-lists are indented with tabs instead of spaces.
+
 - [foo](https://foo.com)
-	- [bar](https://bar.com)
-	- [bar2](https://bar2.com)
-		- [baz](https://baz.com)
-		- [baz2](https://baz2.com)
+  - [bar](https://bar.com)
+  - [bar2](https://bar2.com)
+    - [baz](https://baz.com)
+    - [baz2](https://baz2.com)
 
 These sub-lists use mixed indentation (spaces and tabs).
-- [Python](https://github.com/vinta/awesome-python#readme)
-	- [Asyncio](https://github.com/timofurrer/awesome-asyncio#readme) - Asynchronous I/O in Python 3.
-	- [Scientific Audio](https://github.com/faroit/awesome-python-scientific-audio#readme) - Scientific research in audio/music.
-  - [CircuitPython](https://github.com/adafruit/awesome-circuitpython#readme) - A version of Python for microcontrollers.
 
+- [Python](https://github.com/vinta/awesome-python#readme)
+
+  - [Asyncio](https://github.com/timofurrer/awesome-asyncio#readme) - Asynchronous I/O in Python 3.
+  - [Scientific Audio](https://github.com/faroit/awesome-python-scientific-audio#readme) - Scientific research in audio/music.
+  - [CircuitPython](https://github.com/adafruit/awesome-circuitpython#readme) - A version of Python for microcontrollers.
 
 - [why-is-node-running](https://github.com/mafintosh/why-is-node-running) - Node.js is running but you don't know why?
 
-
 - [gtkada] - Ada graphical toolkit based on Gtk3 components (issue #161 link reference below but checked by `remark-lint-no-undefined-references` not `rules/list-item.js`).
-- [*example* `code`][exampleref] - Another linkref but with children.
+- [_example_ `code`][exampleref] - Another linkref but with children.
 - [foo](https://foo.com) ![stars](https://img.shields.io/github/stars/foo/foo.svg) - Valid description.
 - ![v3](img/vapor-3.png) [API Error Middleware](https://github.com/skelpo/APIErrorMiddleware) - Vapor middleware for converting thrown errors to JSON responses.
 - ![v2](img/vapor-2.png) ![v3](img/vapor-3.png) [Bugsnag](https://github.com/nodes-vapor/bugsnag) - Report errors with Bugsnag.
+- [![v2](img/vapor-2.png)](#-) [![v3](img/vapor-3.png)](#- "Tooltip") [Bugsnag](https://github.com/nodes-vapor/bugsnag) - Report errors with Bugsnag.
 - [ArcGIS location services - Postman Workspace](https://www.postman.com/arcgis-developer/workspace/arcgis-location-services) - Official Postman collections to work with the Geocoding & Search API, Routing & Directions API, Demographics & GeoEnrichment API, Data hosting and more (issue #146).
 - [rmw](https://github.com/ros2/rmw/tree/master/rmw) - Contains the ROS middleware API ![rmw](https://img.shields.io/github/stars/ros2/rmw.svg) (issue #49).
 <!-- TODO
-- [__Compiling machine learning programs via high-level tracing__. Roy Frostig, Matthew James Johnson, Chris Leary. _MLSys 2018_.](https://mlsys.org/Conferences/doc/2018/146.pdf) - This white paper describes an early version of JAX, detailing how computation is traced and compiled (issue #136)
--->
+- [**Compiling machine learning programs via high-level tracing**. Roy Frostig, Matthew James Johnson, Chris Leary. _MLSys 2018_.](https://mlsys.org/Conferences/doc/2018/146.pdf) - This white paper describes an early version of JAX, detailing how computation is traced and compiled (issue #136)
+  -->
 
 [gtkada]: https://github.com/AdaCore/gtkada
 [exampleref]: https://example.com


### PR DESCRIPTION
# Fix for #199

The previous algorithm solved for pattern: `[^{link}{linkReference}]* ({link}|{linkReference}) [^{link}]* " - " {description} `

The new algorithm solves for pattern: `{any}* ({link}|{linkReference}) [^{link}]* " - " {description}?`

It does this by finding a text node starting with ` - `. This node and those after are the description, and nodes before are searched backwards to find a valid {link} or {linkReference}. This will be the checked link.

## References

Links to https://github.com/sindresorhus/awesome-lint/issues/199

Issue identified in https://github.com/sancarn/awesome-vba/issues/12

Related PR: #185