### PR TITLE
Change after to next in badge rule

### DIFF
--- a/rules/badge.js
+++ b/rules/badge.js
@@ -41,7 +41,7 @@ const badgeRule = lintRule('remark-lint:awesome-badge', (ast, file) => {
 		}
 
 		if (!hasBadge) {
-			file.message('Missing Awesome badge after the main heading', node);
+			file.message('Missing Awesome badge right next of the main heading', node);
 		}
 	});
 });

--- a/test/rules/badge.js
+++ b/test/rules/badge.js
@@ -16,7 +16,7 @@ test('badge - missing', async t => {
 		{
 			line: 1,
 			ruleId: 'awesome-badge',
-			message: 'Missing Awesome badge after the main heading',
+			message: 'Missing Awesome badge right next of the main heading',
 		},
 	]);
 });


### PR DESCRIPTION
I believe it is more clear. After implies beside.

I tried putting it after but it wouldn't stop throwing errors until the badge was placed next to it.

The guidelines also read:

> Should be placed on the right side of the readme heading.