### PR TITLE
Update example GH action

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,7 +103,7 @@ jobs:
   Awesome_Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: npx awesome-lint


### PR DESCRIPTION
When I was setting up `awesome-lint` for an awesome list I am working on, I noticed the example checkout code action was using an older version. This pull request updates the sample code for a GitHub action from v2 -> v4. Thanks!