### PR TITLE
Remove blockquote

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 	<br>
 </h1>
 
-> Linter for [Awesome](https://awesome.re) lists
+Linter for [Awesome](https://awesome.re) lists
 
 Intended to make it easier to create and maintain Awesome lists.
 


### PR DESCRIPTION
`>` denotes a `<blockquote>` in Markdown and is rendered as such.

> The blockquote element represents a section that is quoted from another source.

— W3C HTML spec, https://html.spec.whatwg.org/multipage/grouping-content.html#the-blockquote-element

This block was not not quoting a source. I’m not sure if this was just an oversight.