### PR TITLE
Fix false positives in `balanced-punctuation`

### DIFF
--- a/rules/balanced-punctuation.js
+++ b/rules/balanced-punctuation.js
@@ -296,9 +296,34 @@ function processText(context) {
 		const character = text[index];
 		const position = positions[index];
 
-		// Skip apostrophes (contractions like "don't", "it's")
+		// Skip apostrophes (contractions like "don't", "it's").
+		// The original match-punctuation plugin (from remark-lint-plugins) had a
+		// similar false-positive bug, reported in #104 and
+		// https://github.com/laysent/remark-lint-plugins/issues/44.
+		// The fix in 234526338dee handled it, but af84612b5d0c replaced the
+		// plugin with this custom balanced-punctuation implementation and
+		// reintroduced the issue: a right single quote (U+2019) after a word
+		// character was always treated as an apostrophe, even when it was the
+		// closing half of a quoted span (e.g. the ' in 'steal').
 		if ((character === '\u2019' || character === '\'') && isApostrophe(text, index)) {
-			continue;
+			const after = text[index + 1];
+			if (isWordCharacter(after)) {
+				// Between word characters: always an apostrophe ("don't", "it's").
+				continue;
+			}
+
+			// At word boundary ("students'" or closing quote in "'steal'"):
+			// check if there's a matching opening quote on the stack.
+			const hasMatchingOpen = character === '\u2019'
+				? stack.some(item => item?.pair?.left === '\u2018')
+				: symmetricState.get(character);
+
+			if (!hasMatchingOpen) {
+				// No opening to match: treat as apostrophe ("students'").
+				continue;
+			}
+
+			// Matching opening exists: fall through to handle as closing quote.
 		}
 
 		// Check for symmetric pairs (example: straight quotes)

--- a/rules/balanced-punctuation.js
+++ b/rules/balanced-punctuation.js
@@ -212,7 +212,7 @@ For proper nesting, we check if the last stack item matches. If not, we report a
 @param {object} context - Execution context with all necessary data.
 */
 function handleSymmetricPair(context) {
-	const {character, position, stack, symmetricState, symmetricPairs, file} = context;
+	const {character, position, stack, symmetricState, symmetricPairs, file, textIndex} = context;
 	const pair = symmetricPairs.get(character);
 	const expectingClose = symmetricState.get(character);
 
@@ -239,7 +239,7 @@ function handleSymmetricPair(context) {
 	}
 
 	// This is an opening quote
-	stack.push({pair, position});
+	stack.push({pair, position, textIndex});
 	symmetricState.set(character, true);
 }
 
@@ -313,17 +313,31 @@ function processText(context) {
 			}
 
 			// At word boundary ("students'" or closing quote in "'steal'"):
-			// check if there's a matching opening quote on the stack.
-			const hasMatchingOpen = character === '\u2019'
-				? stack.some(item => item?.pair?.left === '\u2018')
-				: symmetricState.get(character);
+			// find the most recent matching opening quote on the stack.
+			const matchingOpenerIndex = character === '\u2019'
+				? stack.findLastIndex(item => item?.pair?.left === '\u2018')
+				: (symmetricState.get(character)
+					? stack.findLastIndex(item => item?.pair?.left === character)
+					: -1);
 
-			if (!hasMatchingOpen) {
+			if (matchingOpenerIndex === -1) {
 				// No opening to match: treat as apostrophe ("students'").
 				continue;
 			}
 
-			// Matching opening exists: fall through to handle as closing quote.
+			// Check whether there is whitespace between the opener and
+			// this position. Possessive apostrophes within a longer
+			// phrase (like 'The students') have whitespace between the
+			// opening quote and the apostrophe. Single-word quotes
+			// (like 'steal') do not.
+			const opener = stack[matchingOpenerIndex];
+			const textBetween = text.slice(opener.textIndex + 1, index);
+			if (/\s/.test(textBetween)) {
+				continue;
+			}
+
+			// No whitespace: single-word quote. Fall through to handle
+			// as closing quote.
 		}
 
 		// Check for symmetric pairs (example: straight quotes)
@@ -335,6 +349,7 @@ function processText(context) {
 				symmetricState,
 				symmetricPairs,
 				file,
+				textIndex: index,
 			});
 
 			continue;
@@ -343,7 +358,7 @@ function processText(context) {
 		// Check for asymmetric left punctuation (opening)
 		if (leftCharacters.has(character)) {
 			const pair = leftCharacters.get(character);
-			stack.push({pair, position});
+			stack.push({pair, position, textIndex: index});
 			continue;
 		}
 

--- a/test/fixtures/balanced-punctuation/apostrophes-invalid.md
+++ b/test/fixtures/balanced-punctuation/apostrophes-invalid.md
@@ -15,3 +15,7 @@ Unmatched curly single quotes (should error).
 Unmatched curly double quotes (should error).
 
 - [Example](https://example.com) - Has unmatched “opening double quote here.
+
+Unmatched curly single quote before possessive (should error).
+
+- [Example](https://example.com) - ‘The students’ books were on the table.

--- a/test/fixtures/balanced-punctuation/apostrophes-invalid.md
+++ b/test/fixtures/balanced-punctuation/apostrophes-invalid.md
@@ -1,0 +1,17 @@
+# Awesome Test [![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re)
+
+> Test list.
+
+## Contents
+
+- [Section](#section)
+
+## Section
+
+Unmatched curly single quotes (should error).
+
+- [Example](https://example.com) - Has unmatched ‘opening single quote here.
+
+Unmatched curly double quotes (should error).
+
+- [Example](https://example.com) - Has unmatched “opening double quote here.

--- a/test/fixtures/balanced-punctuation/apostrophes-valid.md
+++ b/test/fixtures/balanced-punctuation/apostrophes-valid.md
@@ -1,0 +1,45 @@
+# Awesome Test [![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re)
+
+> Test list.
+
+## Contents
+
+- [Section](#section)
+
+## Section
+
+Possessives with curly apostrophes.
+
+- [Example](https://example.com) - Monitor your company’s financial performance.
+- [Example](https://example.com) - The students’ books were on the table.
+
+Contractions with curly apostrophes.
+
+- [Example](https://example.com) - This tool doesn’t require installation.
+- [Example](https://example.com) - It’s a great resource for beginners.
+
+Curly single quotes around words (balanced pairs).
+
+- [Example](https://example.com) - The so-called ‘steal’ was a marketing stunt.
+- [Example](https://example.com) - Read the chapter titled ‘Rivers’ first.
+
+Mixed apostrophes and curly quotes on the same line.
+
+- [Example](https://example.com) - China’s report on the ‘stolen’ vouchers.
+- [Example](https://example.com) - Don’t ‘think’ about it too much.
+
+Balanced curly double quotes (should still work).
+
+- [Example](https://example.com) - The article called it “a revolution” in pricing.
+
+Balanced straight double quotes.
+
+- [Example](https://example.com) - The article called it "a revolution" in pricing.
+
+Nested curly quotes.
+
+- [Example](https://example.com) - “He said ‘hello’ to everyone,” she recalled.
+
+Multiple possessives on the same line.
+
+- [Example](https://example.com) - The company’s and employee’s concerns were addressed.

--- a/test/rules/balanced-punctuation.test.js
+++ b/test/rules/balanced-punctuation.test.js
@@ -64,6 +64,43 @@ describe('balanced-punctuation', () => {
 		assert.ok(errors.length > 0, 'Should detect straight quotes');
 	});
 
+	// Regression test for #104 and https://github.com/laysent/remark-lint-plugins/issues/44.
+	// The custom balanced-punctuation rule (af84612b5d0c) reintroduced the
+	// apostrophe false-positive that was fixed in match-punctuation (234526338dee).
+	it('should not false-positive on apostrophes in possessives and contractions', async () => {
+		const config = {
+			plugins: [
+				remarkLint,
+				balancedPunctuationRule,
+			],
+		};
+
+		const messages = await lint({
+			config,
+			filename: 'test/fixtures/balanced-punctuation/apostrophes-valid.md',
+		});
+
+		const errors = messages.filter(m => m.ruleId === 'balanced-punctuation');
+		assert.equal(errors.length, 0, `Expected no errors but got: ${JSON.stringify(errors, null, 2)}`);
+	});
+
+	it('should detect unmatched curly single quotes that are not apostrophes', async () => {
+		const config = {
+			plugins: [
+				remarkLint,
+				balancedPunctuationRule,
+			],
+		};
+
+		const messages = await lint({
+			config,
+			filename: 'test/fixtures/balanced-punctuation/apostrophes-invalid.md',
+		});
+
+		const errors = messages.filter(m => m.ruleId === 'balanced-punctuation');
+		assert.ok(errors.length > 0, 'Should detect unmatched curly single quotes');
+	});
+
 	it('should not detect defaults when using custom config', async () => {
 		const config = {
 			plugins: [


### PR DESCRIPTION
This PR fix false positives in `balanced-punctuation` for apostrophes.

## Description

The `balanced-punctuation` rule treats `'` (U+2019) after a word character as an apostrophe and skips it. This works for `company's` or `don't`, but breaks when the same line also contains a curly-quoted span like `'steal'`, in which the closing `'` after `steal` has a word character before it and space after it, so it gets classified as an apostrophe too, leaving the opening `'` unmatched.

I stumbled upon this issue in my [awesome-billing](https://github.com/kdeldycke/awesome-billing/commit/c822379c846d534897b10c362003a2b6f341f874) project, where I had to add `<!--lint ignore balanced-punctuation-->` to bypass this false-positive:

```
✖  372:86   Unclosed ' without matching closing '  remark-lint:balanced-punctuation
✖  402:252  Unclosed ' without matching closing '  remark-lint:balanced-punctuation
```

Line 402 has `China's` (apostrophe) and `'steal'` (quoted span) on the same line: 3 `'` characters total, with the closing quote misidentified as an apostrophe.

## Root cause

The original `match-punctuation` plugin from `remark-lint-plugins` had a similar issue (see: #104 and https://github.com/laysent/remark-lint-plugins/issues/44), which was fixed in 234526338dee. Then af84612b5d0c replaced the plugin with the custom `balanced-punctuation` implementation and reintroduced the same class of bug.

## Fix

When `isApostrophe()` returns true but the character is at a word boundary (not between two word characters), check whether there's a matching opening `'` (U+2018) on the stack.

## Context

I contributed the quote/punctuation validation logic in the `list-item` rule 6 years ago (see: #101 and #127) and ran into this `balanced-punctuation` regression on my downstream awesome lists.