### PR TITLE
Add header image rule

### DIFF
--- a/rules/badge.js
+++ b/rules/badge.js
@@ -12,8 +12,8 @@ const badgeSourceUrlAllowList = new Set([
 	'https://awesome.re/badge-flat2.svg',
 ]);
 
-const isValidBadgeUrl = url => badgeUrlAllowList.has(url);
-const isValidBadgeSourceUrl = url => badgeSourceUrlAllowList.has(url);
+export const isValidBadgeUrl = url => badgeUrlAllowList.has(url);
+export const isValidBadgeSourceUrl = url => badgeSourceUrlAllowList.has(url);
 
 const badgeRule = lintRule('remark-lint:awesome-badge', (ast, file) => {
 	visit(ast, 'heading', (node, index) => {

--- a/rules/header-image.js
+++ b/rules/header-image.js
@@ -1,0 +1,292 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {lintRule} from 'unified-lint-rule';
+import {isValidBadgeSourceUrl, isValidBadgeUrl} from './badge.js';
+
+const message = 'Header image must be SVG or high-DPI';
+const imageTagPattern = /<img\b[^>]*>/gi;
+const highDpiFilenamePattern = /(?:^|[.@_-])[234]x(?:[._-]|$)/i;
+const nonStartOfFrameJpegMarkers = new Set([0xC4, 0xC8, 0xCC]);
+
+const headerImageRule = lintRule('remark-lint:awesome-header-image', (ast, file) => {
+	for (const image of findHeaderImages(ast)) {
+		if (isAwesomeBadgeImage(image) || isValidHeaderImage(image, file)) {
+			continue;
+		}
+
+		file.message(message, image.node);
+	}
+});
+
+function findHeaderImages(ast) {
+	const images = [];
+	const children = ast.children ?? [];
+	const headingIndex = children.findIndex(node => node.type === 'heading' && node.depth === 1);
+
+	if (headingIndex === -1) {
+		const firstNode = children.find(node => !isBlankHtmlNode(node));
+
+		if (firstNode?.type === 'html') {
+			addFirstHtmlImage(images, firstNode);
+		}
+
+		return images;
+	}
+
+	for (let index = 0; index < headingIndex; index++) {
+		const node = children[index];
+
+		if (node.type === 'html') {
+			addFirstHtmlImage(images, node);
+			continue;
+		}
+
+		if (!isBlankHtmlNode(node)) {
+			break;
+		}
+	}
+
+	findMarkdownImages(children[headingIndex], images);
+
+	const nextNode = findNextSignificantNode(children, headingIndex + 1);
+
+	if (nextNode?.type === 'html') {
+		addFirstHtmlImage(images, nextNode);
+	} else if (isImageOnlyParagraph(nextNode)) {
+		findMarkdownImages(nextNode, images);
+	}
+
+	return images;
+}
+
+function findNextSignificantNode(nodes, startIndex) {
+	for (let index = startIndex; index < nodes.length; index++) {
+		const node = nodes[index];
+
+		if (!isBlankHtmlNode(node)) {
+			return node;
+		}
+	}
+}
+
+function isBlankHtmlNode(node) {
+	return node?.type === 'html' && node.value.trim() === '';
+}
+
+function isImageOnlyParagraph(node) {
+	if (node?.type !== 'paragraph') {
+		return false;
+	}
+
+	return node.children.every(child => {
+		if (child.type === 'image') {
+			return true;
+		}
+
+		if (child.type === 'link') {
+			return child.children.every(linkChild => linkChild.type === 'image');
+		}
+
+		return child.type === 'text' && child.value.trim() === '';
+	});
+}
+
+function addFirstHtmlImage(images, node) {
+	const image = findHtmlImages(node).find(image => !isAwesomeBadgeImage(image));
+
+	if (image) {
+		images.push(image);
+	}
+}
+
+function findMarkdownImages(node, images, linkUrl) {
+	if (node.type === 'image') {
+		images.push({
+			node,
+			url: node.url,
+			linkUrl,
+		});
+
+		return;
+	}
+
+	for (const child of node.children ?? []) {
+		findMarkdownImages(child, images, node.type === 'link' ? node.url : linkUrl);
+	}
+}
+
+function findHtmlImages(node) {
+	const images = [];
+
+	for (const match of node.value.matchAll(imageTagPattern)) {
+		const attributes = parseAttributes(match[0]);
+		const url = attributes.get('src');
+
+		if (!url) {
+			continue;
+		}
+
+		images.push({
+			node,
+			url,
+			width: parseDisplaySize(attributes.get('width')),
+			height: parseDisplaySize(attributes.get('height')),
+		});
+	}
+
+	return images;
+}
+
+function parseAttributes(tag) {
+	const attributes = new Map();
+	const source = tag
+		.replace(/^<\s*img\b/i, '')
+		.replace(/\/?\s*>$/i, '');
+	const attributePattern = /([^\s"'<>/=]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+
+	for (const match of source.matchAll(attributePattern)) {
+		attributes.set(match[1].toLowerCase(), match[2] ?? match[3] ?? match[4] ?? '');
+	}
+
+	return attributes;
+}
+
+function parseDisplaySize(value) {
+	const match = value?.trim().match(/^(\d+(?:\.\d+)?)\s*(?:px)?$/i);
+	return match ? Number(match[1]) : undefined;
+}
+
+function isAwesomeBadgeImage(image) {
+	return isValidBadgeSourceUrl(image.url) || isValidBadgeUrl(image.linkUrl);
+}
+
+function isValidHeaderImage(image, file) {
+	if (isSvg(image.url)) {
+		return true;
+	}
+
+	const dimensions = getLocalImageDimensions(file, image.url);
+	const hasDisplaySize = Boolean(image.width ?? image.height);
+
+	if (dimensions && hasDisplaySize) {
+		return isHighDpi({
+			displayWidth: image.width,
+			displayHeight: image.height,
+			intrinsicWidth: dimensions.width,
+			intrinsicHeight: dimensions.height,
+		});
+	}
+
+	return highDpiFilenamePattern.test(getUrlPathname(image.url));
+}
+
+function isSvg(url) {
+	const pathname = getUrlPathname(url).toLowerCase();
+	return pathname.endsWith('.svg') || pathname.endsWith('.svgz') || url.toLowerCase().startsWith('data:image/svg+xml');
+}
+
+function isHighDpi({displayWidth, displayHeight, intrinsicWidth, intrinsicHeight}) {
+	if (displayWidth && intrinsicWidth < displayWidth * 2) {
+		return false;
+	}
+
+	if (displayHeight && intrinsicHeight < displayHeight * 2) {
+		return false;
+	}
+
+	return true;
+}
+
+function getLocalImageDimensions(file, url) {
+	const pathname = getUrlPathname(url);
+
+	if (!pathname || /^[a-z][a-z\d+.-]*:/i.test(pathname) || path.isAbsolute(pathname)) {
+		return;
+	}
+
+	const directory = file.dirname ?? (file.path ? path.dirname(file.path) : undefined);
+
+	if (!directory) {
+		return;
+	}
+
+	try {
+		return getImageDimensions(fs.readFileSync(path.resolve(directory, decodeURIComponent(pathname))));
+	} catch {}
+}
+
+function getUrlPathname(url) {
+	return url.split(/[?#]/, 1)[0];
+}
+
+function getImageDimensions(buffer) {
+	return getPngDimensions(buffer) ?? getJpegDimensions(buffer) ?? getGifDimensions(buffer);
+}
+
+function getPngDimensions(buffer) {
+	if (
+		buffer.length < 24
+		|| buffer[0] !== 0x89
+		|| buffer.toString('ascii', 1, 4) !== 'PNG'
+	) {
+		return;
+	}
+
+	return {
+		width: buffer.readUInt32BE(16),
+		height: buffer.readUInt32BE(20),
+	};
+}
+
+function getJpegDimensions(buffer) {
+	if (buffer.length < 4 || buffer[0] !== 0xFF || buffer[1] !== 0xD8) {
+		return;
+	}
+
+	let offset = 2;
+
+	while (offset < buffer.length) {
+		if (buffer[offset] !== 0xFF) {
+			return;
+		}
+
+		const marker = buffer[offset + 1];
+		offset += 2;
+
+		if (marker === 0xDA || marker === 0xD9 || offset + 2 > buffer.length) {
+			return;
+		}
+
+		const length = buffer.readUInt16BE(offset);
+
+		if (length < 2 || offset + length > buffer.length) {
+			return;
+		}
+
+		if (isJpegStartOfFrame(marker)) {
+			return {
+				height: buffer.readUInt16BE(offset + 3),
+				width: buffer.readUInt16BE(offset + 5),
+			};
+		}
+
+		offset += length;
+	}
+}
+
+function isJpegStartOfFrame(marker) {
+	return marker >= 0xC0 && marker <= 0xCF && !nonStartOfFrameJpegMarkers.has(marker);
+}
+
+function getGifDimensions(buffer) {
+	if (buffer.length < 10 || !['GIF87a', 'GIF89a'].includes(buffer.toString('ascii', 0, 6))) {
+		return;
+	}
+
+	return {
+		width: buffer.readUInt16LE(6),
+		height: buffer.readUInt16LE(8),
+	};
+}
+
+export default headerImageRule;

--- a/rules/index.js
+++ b/rules/index.js
@@ -1,5 +1,6 @@
 import heading from './heading.js';
 import badge from './badge.js';
+import headerImage from './header-image.js';
 import contributing from './contributing.js';
 /// import gitRepoAge from './git-repo-age.js';
 import github from './github.js';
@@ -25,6 +26,7 @@ const createRules = (options = {}) => {
 	const rules = [
 		[heading, ['error']],
 		[badge, ['error']],
+		[headerImage, ['error']],
 		[contributing, ['error']],
 
 		// Disabled for now as it means we cannot sparsely check out the repo.

--- a/test/fixtures/header-image/error-h1-followed-by-low-dpi-png.md
+++ b/test/fixtures/header-image/error-h1-followed-by-low-dpi-png.md
@@ -1,0 +1,5 @@
+# Awesome Header
+
+<img width="501" height="350" src="../../../media/logo.png" alt="Awesome">
+
+> A curated list.

--- a/test/fixtures/header-image/error-raster-without-display-size.md
+++ b/test/fixtures/header-image/error-raster-without-display-size.md
@@ -1,0 +1,5 @@
+# Awesome Header
+
+<img src="../../../media/logo.png" alt="Awesome">
+
+> A curated list.

--- a/test/fixtures/header-image/success-awesome-badge.md
+++ b/test/fixtures/header-image/success-awesome-badge.md
@@ -1,0 +1,3 @@
+# Awesome Header [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+
+> A curated list.

--- a/test/fixtures/header-image/success-h1-followed-by-high-dpi-png.md
+++ b/test/fixtures/header-image/success-h1-followed-by-high-dpi-png.md
@@ -1,0 +1,5 @@
+# Awesome Header
+
+<img width="500" height="350" src="../../../media/logo.png" alt="Awesome">
+
+> A curated list.

--- a/test/fixtures/header-image/success-h1-followed-by-svg.md
+++ b/test/fixtures/header-image/success-h1-followed-by-svg.md
@@ -1,0 +1,5 @@
+# Awesome Header
+
+<img width="500" src="../../../media/logo.svg" alt="Awesome">
+
+> A curated list.

--- a/test/fixtures/header-image/success-html-h1-svg.md
+++ b/test/fixtures/header-image/success-html-h1-svg.md
@@ -1,0 +1,5 @@
+<h1 align="center">
+	<img width="500" src="../../../media/logo.svg" alt="Awesome">
+</h1>
+
+> A curated list.

--- a/test/fixtures/header-image/success-later-images-in-header-block.md
+++ b/test/fixtures/header-image/success-later-images-in-header-block.md
@@ -1,0 +1,7 @@
+<div align="center">
+	<img width="500" src="../../../media/logo.svg" alt="Awesome">
+	<br>
+	<img width="501" height="350" src="../../../media/logo.png" alt="Sponsor">
+</div>
+
+> A curated list.

--- a/test/rules/header-image.test.js
+++ b/test/rules/header-image.test.js
@@ -1,0 +1,61 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import remarkLint from 'remark-lint';
+import lint from '../_lint.js';
+import headerImageRule from '../../rules/header-image.js';
+
+describe('rules › header-image', () => {
+	const config = {
+		plugins: [
+			remarkLint,
+			headerImageRule,
+		],
+	};
+
+	it('header-image - success (h1 followed by svg)', async () => {
+		const messages = await lint({config, filename: 'test/fixtures/header-image/success-h1-followed-by-svg.md'});
+		assert.deepEqual(messages, []);
+	});
+
+	it('header-image - success (h1 followed by high-dpi png)', async () => {
+		const messages = await lint({config, filename: 'test/fixtures/header-image/success-h1-followed-by-high-dpi-png.md'});
+		assert.deepEqual(messages, []);
+	});
+
+	it('header-image - success (html h1 svg)', async () => {
+		const messages = await lint({config, filename: 'test/fixtures/header-image/success-html-h1-svg.md'});
+		assert.deepEqual(messages, []);
+	});
+
+	it('header-image - success (later images in header block)', async () => {
+		const messages = await lint({config, filename: 'test/fixtures/header-image/success-later-images-in-header-block.md'});
+		assert.deepEqual(messages, []);
+	});
+
+	it('header-image - success (awesome badge)', async () => {
+		const messages = await lint({config, filename: 'test/fixtures/header-image/success-awesome-badge.md'});
+		assert.deepEqual(messages, []);
+	});
+
+	it('header-image - error (h1 followed by low-dpi png)', async () => {
+		const messages = await lint({config, filename: 'test/fixtures/header-image/error-h1-followed-by-low-dpi-png.md'});
+		assert.deepEqual(messages, [
+			{
+				line: 3,
+				ruleId: 'awesome-header-image',
+				message: 'Header image must be SVG or high-DPI',
+			},
+		]);
+	});
+
+	it('header-image - error (raster image without display size)', async () => {
+		const messages = await lint({config, filename: 'test/fixtures/header-image/error-raster-without-display-size.md'});
+		assert.deepEqual(messages, [
+			{
+				line: 3,
+				ruleId: 'awesome-header-image',
+				message: 'Header image must be SVG or high-DPI',
+			},
+		]);
+	});
+});


### PR DESCRIPTION
Fixes #37

## Summary
- Adds an `awesome-header-image` rule for the funded IssueHunt issue.
- Lints the first non-badge header image and accepts SVG/SVGZ/data SVG or raster images that are at least 2x the displayed size.
- Covers the maintainer-requested `H1` followed by top-level `<img>` layout, plus HTML header blocks and image-only paragraphs after the first H1.
- Avoids flagging later sponsor images in large opening HTML blocks.

## Tests
- `npm test`